### PR TITLE
Fix CTF stream picking logic.

### DIFF
--- a/LTTngCds/CtfExtensions/FolderInput/LTTngFolderInput.cs
+++ b/LTTngCds/CtfExtensions/FolderInput/LTTngFolderInput.cs
@@ -35,7 +35,7 @@ namespace LTTngCds.CtfExtensions.FolderInput
                 Debug.Assert(traceDirectoryPath != null, nameof(traceDirectoryPath) + " != null");
 
                 var associatedEntries = Directory.GetFiles(traceDirectoryPath).Where(entry =>
-                    Path.GetFileName(entry).StartsWith("chan"));
+                    Path.GetFileName(entry) != "metadata");
 
                 traceInput.EventStreams = associatedEntries.Select(
                     fileName => new LTTngFileInputStream(fileName)).Cast<ICtfInputStream>().ToList();

--- a/LTTngCds/CtfExtensions/ZipArchiveInput/LTTngZipArchiveInput.cs
+++ b/LTTngCds/CtfExtensions/ZipArchiveInput/LTTngZipArchiveInput.cs
@@ -39,7 +39,7 @@ namespace LTTngCds.CtfExtensions.ZipArchiveInput
 
                 var associatedArchiveEntries = archive.Entries.Where(entry =>
                     Path.GetDirectoryName(entry.FullName) == traceDirectoryPath &&
-                    Path.GetFileName(entry.FullName).StartsWith("chan"));
+                    Path.GetFileName(entry.FullName) != "metadata");
 
                 traceInput.EventStreams = associatedArchiveEntries.Select(
                     archiveEntry => new LTTngZipArchiveInputStream(archiveEntry)).Cast<ICtfInputStream>().ToList();


### PR DESCRIPTION
Stream picking logic for CTF trace incorrectly assumes that channel name is set to default "channelX" where X is sequence number. Using custom channel names causes no streams to be parsed because containing files has different than default names. In my read of CTF specification all data files contains streams with exception of one file - "metadata". This is what this change implements, all files with exception of "metadata" will be parsed for event streams.