### PR TITLE
Perfetto plugin - Added 3 new tables: CPU frequency, Ftrace events, logcat

### DIFF
--- a/LTTngDataExtensions/LTTngDataExtensions.csproj
+++ b/LTTngDataExtensions/LTTngDataExtensions.csproj
@@ -55,6 +55,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LTTngCds\LTTngCds.csproj" />
+    <ProjectReference Include="..\Utilities\Utilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LTTngDataExtensions/Tables/GenericEventTable.cs
+++ b/LTTngDataExtensions/Tables/GenericEventTable.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography;
 using LTTngDataExtensions.DataOutputTypes;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
+using Utilities;
 
 namespace LTTngDataExtensions.Tables
 {
@@ -81,7 +80,7 @@ namespace LTTngDataExtensions.Tables
 
             var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
 
-            var genericEventProjection = new GenericEventProjection(events);
+            var genericEventProjection = new EventProjection<LTTngGenericEvent>(events);
 
             var eventNameColumn = new BaseDataColumn<string>(
                 eventNameColumnConfig, 
@@ -120,7 +119,7 @@ namespace LTTngDataExtensions.Tables
 
             // generate a column configuration
             var fieldColumnConfiguration = new ColumnConfiguration(
-                    new ColumnMetadata(GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
+                    new ColumnMetadata(Common.GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
                     new UIHints
                     {
                         IsVisible = true,
@@ -134,66 +133,5 @@ namespace LTTngDataExtensions.Tables
             }
 
         }
-
-        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]
-        private static Guid GenerateGuidFromName(string name)
-        {
-            // The algorithm below is following the guidance of http://www.ietf.org/rfc/rfc4122.txt
-            // Create a blob containing a 16 byte number representing the namespace
-            // followed by the unicode bytes in the name.  
-            var bytes = new byte[name.Length * 2 + 16];
-            uint namespace1 = 0x482C2DB2;
-            uint namespace2 = 0xC39047c8;
-            uint namespace3 = 0x87F81A15;
-            uint namespace4 = 0xBFC130FB;
-            // Write the bytes most-significant byte first.  
-            for (int i = 3; 0 <= i; --i)
-            {
-                bytes[i] = (byte)namespace1;
-                namespace1 >>= 8;
-                bytes[i + 4] = (byte)namespace2;
-                namespace2 >>= 8;
-                bytes[i + 8] = (byte)namespace3;
-                namespace3 >>= 8;
-                bytes[i + 12] = (byte)namespace4;
-                namespace4 >>= 8;
-            }
-            // Write out  the name, most significant byte first
-            for (int i = 0; i < name.Length; i++)
-            {
-                bytes[2 * i + 16 + 1] = (byte)name[i];
-                bytes[2 * i + 16] = (byte)(name[i] >> 8);
-            }
-
-            // Compute the Sha1 hash 
-            var sha1 = SHA1.Create();
-            byte[] hash = sha1.ComputeHash(bytes);
-
-            // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)
-            int a = (((((hash[3] << 8) + hash[2]) << 8) + hash[1]) << 8) + hash[0];
-            short b = (short)((hash[5] << 8) + hash[4]);
-            short c = (short)((hash[7] << 8) + hash[6]);
-
-            c = (short)((c & 0x0FFF) | 0x5000);   // Set high 4 bits of octet 7 to 5, as per RFC 4122
-            Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
-            return guid;
-        }
-    }
-
-    public struct GenericEventProjection
-        : IProjection<int, LTTngGenericEvent>
-    {
-        private readonly ProcessedEventData<LTTngGenericEvent> genericEvents;
-
-        public GenericEventProjection(ProcessedEventData<LTTngGenericEvent> genericEvents)
-        {
-            this.genericEvents = genericEvents;
-        }
-
-        public Type SourceType => typeof(int);
-
-        public Type ResultType => typeof(LTTngGenericEvent);
-
-        public LTTngGenericEvent this[int value] => this.genericEvents[(uint)value];
     }
 }

--- a/Microsoft-Perf-Tools-Linux.sln
+++ b/Microsoft-Perf-Tools-Linux.sln
@@ -53,7 +53,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerfettoCds", "PerfettoCds\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerfettoProcessor", "PerfettoProcessor\PerfettoProcessor.csproj", "{90FE5422-631F-4B5A-8EF7-88FE542739DF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfettoUnitTest", "PerfettoUnitTest\PerfettoUnitTest.csproj", "{CF89184C-8CE8-4656-9C5C-3F6C547EF2A3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerfettoUnitTest", "PerfettoUnitTest\PerfettoUnitTest.csproj", "{CF89184C-8CE8-4656-9C5C-3F6C547EF2A3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utilities", "Utilities\Utilities.csproj", "{0BA62F1B-1456-48FD-B2DE-C9FE1CB94B8B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -141,6 +143,10 @@ Global
 		{CF89184C-8CE8-4656-9C5C-3F6C547EF2A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF89184C-8CE8-4656-9C5C-3F6C547EF2A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF89184C-8CE8-4656-9C5C-3F6C547EF2A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BA62F1B-1456-48FD-B2DE-C9FE1CB94B8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BA62F1B-1456-48FD-B2DE-C9FE1CB94B8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BA62F1B-1456-48FD-B2DE-C9FE1CB94B8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BA62F1B-1456-48FD-B2DE-C9FE1CB94B8B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PerfDataExtensions/PerfDataExtensions.csproj
+++ b/PerfDataExtensions/PerfDataExtensions.csproj
@@ -56,6 +56,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PerfCds\PerfCds.csproj" />
+    <ProjectReference Include="..\Utilities\Utilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PerfDataExtensions/Tables/GenericEventTable.cs
+++ b/PerfDataExtensions/Tables/GenericEventTable.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography;
 using CtfPlayback.FieldValues;
 using PerfDataExtensions.DataOutputTypes;
 using Microsoft.Performance.SDK;
 using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
+using Utilities;
 
 namespace PerfDataExtensions.Tables
 {
@@ -74,7 +73,7 @@ namespace PerfDataExtensions.Tables
 
             var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
 
-            var genericEventProjection = new GenericEventProjection(events);
+            var genericEventProjection = new EventProjection<PerfGenericEvent>(events);
 
             var eventNameColumn = new BaseDataColumn<string>(
                 eventNameColumnConfig, 
@@ -110,7 +109,7 @@ namespace PerfDataExtensions.Tables
 
                 // generate a column configuration
                 var fieldColumnConfiguration = new ColumnConfiguration(
-                    new ColumnMetadata(GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
+                    new ColumnMetadata(Common.GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
                     new UIHints
                     {
                         IsVisible = true,
@@ -124,67 +123,6 @@ namespace PerfDataExtensions.Tables
                 tableGenerator.AddColumn(fieldColumnConfiguration, genericEventFieldAsStringProjection);
             }
         }
-
-        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]
-        private static Guid GenerateGuidFromName(string name)
-        {
-            // The algorithm below is following the guidance of http://www.ietf.org/rfc/rfc4122.txt
-            // Create a blob containing a 16 byte number representing the namespace
-            // followed by the unicode bytes in the name.  
-            var bytes = new byte[name.Length * 2 + 16];
-            uint namespace1 = 0x482C2DB2;
-            uint namespace2 = 0xC39047c8;
-            uint namespace3 = 0x87F81A15;
-            uint namespace4 = 0xBFC130FB;
-            // Write the bytes most-significant byte first.  
-            for (int i = 3; 0 <= i; --i)
-            {
-                bytes[i] = (byte)namespace1;
-                namespace1 >>= 8;
-                bytes[i + 4] = (byte)namespace2;
-                namespace2 >>= 8;
-                bytes[i + 8] = (byte)namespace3;
-                namespace3 >>= 8;
-                bytes[i + 12] = (byte)namespace4;
-                namespace4 >>= 8;
-            }
-            // Write out  the name, most significant byte first
-            for (int i = 0; i < name.Length; i++)
-            {
-                bytes[2 * i + 16 + 1] = (byte)name[i];
-                bytes[2 * i + 16] = (byte)(name[i] >> 8);
-            }
-
-            // Compute the Sha1 hash 
-            var sha1 = SHA1.Create();
-            byte[] hash = sha1.ComputeHash(bytes);
-
-            // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)
-            int a = (((((hash[3] << 8) + hash[2]) << 8) + hash[1]) << 8) + hash[0];
-            short b = (short)((hash[5] << 8) + hash[4]);
-            short c = (short)((hash[7] << 8) + hash[6]);
-
-            c = (short)((c & 0x0FFF) | 0x5000);   // Set high 4 bits of octet 7 to 5, as per RFC 4122
-            Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
-            return guid;
-        }
-    }
-
-    public struct GenericEventProjection
-        : IProjection<int, PerfGenericEvent>
-    {
-        private readonly ProcessedEventData<PerfGenericEvent> genericEvents;
-
-        public GenericEventProjection(ProcessedEventData<PerfGenericEvent> genericEvents)
-        {
-            this.genericEvents = genericEvents;
-        }
-
-        public Type SourceType => typeof(int);
-
-        public Type ResultType => typeof(PerfGenericEvent);
-
-        public PerfGenericEvent this[int value] => this.genericEvents[(uint)value];
     }
 
     public struct GenericEventFieldProjection

--- a/PerfettoCds/PerfettoCds.csproj
+++ b/PerfettoCds/PerfettoCds.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PerfettoProcessor\PerfettoProcessor.csproj" />
+    <ProjectReference Include="..\Utilities\Utilities.csproj" />
   </ItemGroup>
 
   <Target Name="CopyRulesToTarget" AfterTargets="Build">

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuFrequencyEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuFrequencyEventCooker.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Processing;
+using PerfettoCds.Pipeline.DataOutput;
+using PerfettoProcessor;
+
+namespace PerfettoCds.Pipeline.DataCookers
+{
+    /// <summary>
+    /// Pulls data from multiple individual SQL tables and joins them to create a Generic Peretto event
+    /// </summary>
+    public sealed class PerfettoCpuFrequencyEventCooker : CookedDataReflector, ICompositeDataCookerDescriptor
+    {
+        public static readonly DataCookerPath DataCookerPath = PerfettoPluginConstants.CpuFrequencyEventCookerPath;
+
+        public string Description => "CPU Frequency composite cooker";
+
+        public DataCookerPath Path => DataCookerPath;
+
+        // Declare all of the cookers that are used by this CompositeCooker.
+        public IReadOnlyCollection<DataCookerPath> RequiredDataCookers => new[]
+        {
+            PerfettoPluginConstants.CounterCookerPath,
+            PerfettoPluginConstants.CpuCounterTrackCookerPath
+        };
+
+        [DataOutput]
+        public ProcessedEventData<PerfettoCpuFrequencyEvent> CpuFrequencyEvents { get; }
+
+        public PerfettoCpuFrequencyEventCooker() : base(PerfettoPluginConstants.CpuFrequencyEventCookerPath)
+        { 
+            this.CpuFrequencyEvents =
+                new ProcessedEventData<PerfettoCpuFrequencyEvent>();
+        }
+
+        public void OnDataAvailable(IDataExtensionRetrieval requiredData)
+        {
+            // Gather the data from all the SQL tables
+            var counterData = requiredData.QueryOutput<ProcessedEventData<PerfettoCounterEvent>>(new DataOutputPath(PerfettoPluginConstants.CounterCookerPath, nameof(PerfettoCounterCooker.CounterEvents)));
+            var cpuCounterTrackData = requiredData.QueryOutput<ProcessedEventData<PerfettoCpuCounterTrackEvent>>(new DataOutputPath(PerfettoPluginConstants.CpuCounterTrackCookerPath, nameof(PerfettoCpuCounterTrackCooker.CpuCounterTrackEvents)));
+
+            // Join them all together
+            // TODO describe tables
+            var joined = from counter in counterData
+                         join cpuCounterTrack in cpuCounterTrackData on counter.TrackId equals cpuCounterTrack.Id
+                         where cpuCounterTrack.Name == "cpuidle" || cpuCounterTrack.Name == "cpufreq"
+                         orderby counter.Timestamp ascending
+                         //group new { counter, cpuCounterTrack } by cpuCounterTrack.Cpu into test
+                            select new { counter, cpuCounterTrack };
+
+            int cnt = 0;
+            // Create events out of the joined results
+            foreach (var result in joined.GroupBy(x=>x.cpuCounterTrack.Cpu))
+            {
+                double lastFreq = 0;
+
+                //foreach (var thing in result)
+                for(int i = 0; i < result.Count(); i++)
+                {
+                    var thing = result.ElementAt(i);
+                    var frequency = thing.counter.FloatValue;
+                    var name = thing.cpuCounterTrack.Name;
+                    var ts = thing.counter.Timestamp;
+                    bool isIdle = true;
+
+                    // TODO explain
+                    if (thing.counter.FloatValue == 4294967295)
+                    {
+                        frequency = lastFreq;
+                        isIdle = false;
+                    }
+                    else if (frequency != 0)
+                    {
+                        lastFreq = frequency;
+                        isIdle = false;
+                    }
+
+                    long nextTs = ts;
+                    if (i < result.Count() - 1)
+                    {
+                        nextTs = result.ElementAt(i + 1).counter.Timestamp;
+                    }
+                    
+                    PerfettoCpuFrequencyEvent ev = new PerfettoCpuFrequencyEvent
+                    (
+                        frequency,
+                        thing.cpuCounterTrack.Cpu,
+                        new Timestamp(thing.counter.Timestamp),
+                        new TimestampDelta(nextTs - ts),
+                        name,
+                        isIdle
+                    );
+                    this.CpuFrequencyEvents.AddEvent(ev);
+                }
+                //var frequency = result.counter.FloatValue;
+                //var name = result.cpuCounterTrack.Name;
+                //// TODO explain
+                //if (result.counter.FloatValue == 4294967295)
+                //{
+                //    frequency = 0;
+                //    name = name + "back to not-idle";
+                //}
+                //PerfettoCpuFrequencyEvent ev = new PerfettoCpuFrequencyEvent
+                //(
+                //    frequency,
+                //    result.cpuCounterTrack.Cpu,
+                //    new Timestamp(result.counter.Timestamp),
+                //    name
+                //);
+                //this.CpuFrequencyEvents.AddEvent(ev);
+            }
+            this.CpuFrequencyEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuFrequencyEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoCpuFrequencyEventCooker.cs
@@ -34,10 +34,12 @@ namespace PerfettoCds.Pipeline.DataCookers
         [DataOutput]
         public ProcessedEventData<PerfettoCpuFrequencyEvent> CpuFrequencyEvents { get; }
 
-        // CPU frequency related constants
-        private const string CpuIdleString = "cpuidle";
-        private const string CpuFreqString = "cpufreq";
-        private const long BackToNoIdleLong = 4294967295;
+        /// Frequency scaling related constants. See docs/data-sources/cpu-freq in the Perfetto repo
+        // String constants that define the types of CpuCounterTrack events
+        private const string CpuIdleString = "cpuidle"; // Cpu is transitioning in/out of idle
+        private const string CpuFreqString = "cpufreq"; // Cpu is changing frequency
+        // This value for a 'cpuidle' event indicates the CPU is going back to not-idle.
+        private const long BackToNotIdleCode = 4294967295;
 
         public PerfettoCpuFrequencyEventCooker() : base(PerfettoPluginConstants.CpuFrequencyEventCookerPath)
         { 
@@ -84,7 +86,7 @@ namespace PerfettoCds.Pipeline.DataCookers
                     bool isIdle = true;
 
                     // This means the CPU is going back to non-idle at the last frequency
-                    if (result.counter.FloatValue == BackToNoIdleLong && name == CpuIdleString)
+                    if (result.counter.FloatValue == BackToNotIdleCode && name == CpuIdleString)
                     {
                         frequency = lastFreq;
                         isIdle = false;

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
@@ -13,13 +13,13 @@ using PerfettoProcessor;
 namespace PerfettoCds.Pipeline.DataCookers
 {
     /// <summary>
-    /// Pulls data from multiple individual SQL tables and joins them to create a Generic Peretto event TODO
+    /// Pulls data from multiple individual SQL tables and joins them to create a Ftrace Perfetto event
     /// </summary>
     public sealed class PerfettoFtraceEventCooker : CookedDataReflector, ICompositeDataCookerDescriptor
     {
         public static readonly DataCookerPath DataCookerPath = PerfettoPluginConstants.FtraceEventCookerPath;
 
-        public string Description => "Generic Event composite cooker";
+        public string Description => "Ftrace Event composite cooker";
 
         public DataCookerPath Path => DataCookerPath;
 
@@ -57,7 +57,9 @@ namespace PerfettoCds.Pipeline.DataCookers
 
             // Join them all together
 
-            // TODO describe data
+            // Raw contains all the ftrace events, timestamps, and CPU
+            // Arg contains a variable number of extra arguments for each event.
+            // Thread and process info is contained in their respective tables
             var joined = from raw in rawData
                          join thread in threadData on raw.Utid equals thread.Utid
                          join process in processData on thread.Upid equals process.Upid

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
@@ -13,7 +13,7 @@ using PerfettoProcessor;
 namespace PerfettoCds.Pipeline.DataCookers
 {
     /// <summary>
-    /// Pulls data from multiple individual SQL tables and joins them to create a Ftrace Perfetto event
+    /// Pulls data from multiple individual SQL tables and joins them to create an Ftrace Perfetto event
     /// </summary>
     public sealed class PerfettoFtraceEventCooker : CookedDataReflector, ICompositeDataCookerDescriptor
     {
@@ -73,7 +73,8 @@ namespace PerfettoCds.Pipeline.DataCookers
 
                 List<string> argKeys = new List<string>();
                 List<string> values = new List<string>();
-                // Each event has multiple of these "debug annotations". They get stored in lists
+
+                // Each event has multiple of these arguments. They get stored in lists
                 foreach (var arg in result.args)
                 {
                     argKeys.Add(arg.ArgKey);

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoLogcatEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoLogcatEventCooker.cs
@@ -13,13 +13,13 @@ using PerfettoProcessor;
 namespace PerfettoCds.Pipeline.DataCookers
 {
     /// <summary>
-    /// Pulls data from multiple individual SQL tables and joins them to create a Generic Peretto event TODO
+    /// Pulls data from multiple individual SQL tables and joins them to create events for logcat output
     /// </summary>
     public sealed class PerfettoLogcatEventCooker : CookedDataReflector, ICompositeDataCookerDescriptor
     {
         public static readonly DataCookerPath DataCookerPath = PerfettoPluginConstants.LogcatEventCookerPath;
 
-        public string Description => "Generic Event composite cooker";
+        public string Description => "Logcat event composite cooker";
 
         public DataCookerPath Path => DataCookerPath;
 
@@ -55,7 +55,8 @@ namespace PerfettoCds.Pipeline.DataCookers
 
             // Join them all together
 
-            // TODO describe data
+            // Log contains the information for each logcat message
+            // Thread and process info are gathered from their respective tables
             var joined = from log in androidLogData
                          join thread in threadData on log.Utid equals thread.Utid
                          join process in processData on thread.Upid equals process.Upid

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoLogcatEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoLogcatEventCooker.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Processing;
+using PerfettoCds.Pipeline.DataOutput;
+using PerfettoProcessor;
+
+namespace PerfettoCds.Pipeline.DataCookers
+{
+    /// <summary>
+    /// Pulls data from multiple individual SQL tables and joins them to create a Generic Peretto event TODO
+    /// </summary>
+    public sealed class PerfettoLogcatEventCooker : CookedDataReflector, ICompositeDataCookerDescriptor
+    {
+        public static readonly DataCookerPath DataCookerPath = PerfettoPluginConstants.LogcatEventCookerPath;
+
+        public string Description => "Generic Event composite cooker";
+
+        public DataCookerPath Path => DataCookerPath;
+
+        // Declare all of the cookers that are used by this CompositeCooker.
+        public IReadOnlyCollection<DataCookerPath> RequiredDataCookers => new[]
+        {
+            PerfettoPluginConstants.AndroidLogCookerPath,
+            PerfettoPluginConstants.ThreadCookerPath,
+            PerfettoPluginConstants.ProcessCookerPath
+        };
+
+        [DataOutput]
+        public ProcessedEventData<PerfettoLogcatEvent> LogcatEvents { get; }
+
+        /// <summary>
+        /// The highest number of fields found in any single event.
+        /// </summary>
+        [DataOutput]
+        public int MaximumEventFieldCount { get; private set; }
+
+        public PerfettoLogcatEventCooker() : base(PerfettoPluginConstants.LogcatEventCookerPath)
+        {
+            this.LogcatEvents =
+                new ProcessedEventData<PerfettoLogcatEvent>();
+        }
+
+        public void OnDataAvailable(IDataExtensionRetrieval requiredData)
+        {
+            // Gather the data from all the SQL tables
+            var threadData = requiredData.QueryOutput<ProcessedEventData<PerfettoThreadEvent>>(new DataOutputPath(PerfettoPluginConstants.ThreadCookerPath, nameof(PerfettoThreadCooker.ThreadEvents)));
+            var processData = requiredData.QueryOutput<ProcessedEventData<PerfettoProcessEvent>>(new DataOutputPath(PerfettoPluginConstants.ProcessCookerPath, nameof(PerfettoProcessCooker.ProcessEvents)));
+            var androidLogData = requiredData.QueryOutput<ProcessedEventData<PerfettoAndroidLogEvent>>(new DataOutputPath(PerfettoPluginConstants.AndroidLogCookerPath, nameof(PerfettoAndroidLogCooker.AndroidLogEvents)));
+
+            // Join them all together
+
+            // TODO describe data
+            var joined = from log in androidLogData
+                         join thread in threadData on log.Utid equals thread.Utid
+                         join process in processData on thread.Upid equals process.Upid
+                         select new { log, process };
+
+            // Create events out of the joined results
+            foreach (var result in joined)
+            {
+                PerfettoLogcatEvent ev = new PerfettoLogcatEvent
+                (
+                    new Timestamp(result.log.Timestamp),
+                    result.process.Name,
+                    result.log.PriorityString,
+                    result.log.Tag, 
+                    result.log.Message
+                );
+                this.LogcatEvents.AddEvent(ev);
+            }
+            this.LogcatEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoCpuFrequencyEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoCpuFrequencyEvent.cs
@@ -7,7 +7,6 @@ namespace PerfettoCds.Pipeline.DataOutput
 {
     /// <summary>
     /// A event that represents the frequency and state of a CPU at a point in time
-    /// info.
     /// </summary>
     public readonly struct PerfettoCpuFrequencyEvent
     {

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoCpuFrequencyEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoCpuFrequencyEvent.cs
@@ -11,10 +11,12 @@ namespace PerfettoCds.Pipeline.DataOutput
     /// </summary>
     public readonly struct PerfettoCpuFrequencyEvent
     {
-        // From Slice table
+        // The current frequency of this CPU
         public double CpuFrequency { get; }
+        // The specific CPU core
         public long CpuNum { get; }
         public Timestamp StartTimestamp { get; }
+        // Type of CPU frequency event. Whether it's an idle change or frequency change event
         public string Name { get; }
         public TimestampDelta Duration { get; }
         public bool IsIdle { get; }

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoCpuFrequencyEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoCpuFrequencyEvent.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using System.Collections.Generic;
+
+namespace PerfettoCds.Pipeline.DataOutput
+{
+    /// <summary>
+    /// A event that represents the frequency and state of a CPU at a point in time
+    /// info.
+    /// </summary>
+    public readonly struct PerfettoCpuFrequencyEvent
+    {
+        // From Slice table
+        public double CpuFrequency { get; }
+        public long CpuNum { get; }
+        public Timestamp StartTimestamp { get; }
+        public string Name { get; }
+        public TimestampDelta Duration { get; }
+        public bool IsIdle { get; }
+
+        public PerfettoCpuFrequencyEvent(double cpuFrequency, long cpuNum, Timestamp startTimestamp, TimestampDelta duration, string name, bool isIdle)
+        {
+            this.CpuFrequency = cpuFrequency;
+            this.CpuNum = cpuNum;
+            this.StartTimestamp = startTimestamp;
+            this.Duration = duration;
+            this.Name = name;
+            this.IsIdle = isIdle;
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
@@ -9,28 +9,25 @@ namespace PerfettoCds.Pipeline.DataOutput
     /// A logcat message
     /// info.
     /// </summary>
-    public readonly struct PerfettoLogcatEvent
+    public readonly struct PerfettoFtraceEvent
     {
         public Timestamp StartTimestamp { get; }
         public string ProcessName { get; }
         public string ThreadName { get; }
-        public string Priority { get; }
-        public string Tag { get; }
-        public string Message { get; }
+        public long Cpu { get; }
+        public string Name { get; }
 
-        public PerfettoLogcatEvent(Timestamp startTimestamp,
+        public PerfettoFtraceEvent(Timestamp startTimestamp,
             string processName,
             string threadName,
-            string priority,
-            string tag,
-            string message)
+            long cpu,
+            string name)
         {
             this.StartTimestamp = startTimestamp;
             this.ProcessName = processName;
             this.ThreadName = threadName;
-            this.Priority = priority;
-            this.Tag = tag;
-            this.Message = message;
+            this.Cpu = cpu;
+            this.Name = name;
         }
     }
 }

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
@@ -17,17 +17,25 @@ namespace PerfettoCds.Pipeline.DataOutput
         public long Cpu { get; }
         public string Name { get; }
 
+        // From Args table. Variable number per event
+        public List<string> Values { get; }
+        public List<string> ArgKeys { get; }
+
         public PerfettoFtraceEvent(Timestamp startTimestamp,
             string processName,
             string threadName,
             long cpu,
-            string name)
+            string name,
+            List<string> values,
+            List<string> argKeys)
         {
             this.StartTimestamp = startTimestamp;
             this.ProcessName = processName;
             this.ThreadName = threadName;
             this.Cpu = cpu;
             this.Name = name;
+            this.Values = values;
+            this.ArgKeys = argKeys;
         }
     }
 }

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace PerfettoCds.Pipeline.DataOutput
 {
     /// <summary>
-    /// A logcat message
+    /// An Ftrace event with extra args
     /// info.
     /// </summary>
     public readonly struct PerfettoFtraceEvent
@@ -15,6 +15,7 @@ namespace PerfettoCds.Pipeline.DataOutput
         public string ProcessName { get; }
         public string ThreadName { get; }
         public long Cpu { get; }
+        // Name of the ftrace event
         public string Name { get; }
 
         // From Args table. Variable number per event

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoFtraceEvent.cs.cs
@@ -7,7 +7,6 @@ namespace PerfettoCds.Pipeline.DataOutput
 {
     /// <summary>
     /// An Ftrace event with extra args
-    /// info.
     /// </summary>
     public readonly struct PerfettoFtraceEvent
     {

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoLogcatEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoLogcatEvent.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using System.Collections.Generic;
+
+namespace PerfettoCds.Pipeline.DataOutput
+{
+    /// <summary>
+    /// A logcat message
+    /// info.
+    /// </summary>
+    public readonly struct PerfettoLogcatEvent
+    {
+        public Timestamp StartTimestamp { get; }
+        public string ProcessName { get; }
+        public string Priority { get; }
+        public string Tag { get; }
+        public string Message { get; }
+
+        public PerfettoLogcatEvent(Timestamp startTimestamp,
+            string processName,
+            string priority,
+            string tag,
+            string message)
+        {
+            this.StartTimestamp = startTimestamp;
+            this.ProcessName = processName;
+            this.Priority = priority;
+            this.Tag = tag;
+            this.Message = message;
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoLogcatEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoLogcatEvent.cs
@@ -7,7 +7,6 @@ namespace PerfettoCds.Pipeline.DataOutput
 {
     /// <summary>
     /// A logcat message
-    /// info.
     /// </summary>
     public readonly struct PerfettoLogcatEvent
     {

--- a/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
+++ b/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
@@ -19,10 +19,12 @@ namespace PerfettoCds
         public const string ThreadTrackCookerId = "PerfettoThreadCookerId";
         public const string ProcessCookerId = "PerfettoProcessCooker";
         public const string SchedSliceCookerId = "PerfettoSchedSliceCooker";
+        public const string AndroidLogCookerId = "PerfettoAndroidLogCooker";
 
         // ID for composite data cookers
         public const string GenericEventCookerId = "PerfettoGenericEventCooker";
         public const string CpuSchedEventCookerId = "PerfettoCpuSchedEventCooker";
+        public const string LogcatEventCookerId = "PerfettoLogcatEventCooker";
 
         // Events for source cookers
         public const string SliceEvent = PerfettoSliceEvent.Key;
@@ -31,10 +33,12 @@ namespace PerfettoCds
         public const string ThreadEvent = PerfettoThreadEvent.Key;
         public const string ProcessEvent = PerfettoProcessEvent.Key;
         public const string SchedSliceEvent = PerfettoSchedSliceEvent.Key;
+        public const string AndroidLogEvent = PerfettoAndroidLogEvent.Key;
 
         // Output events for composite cookers
         public const string GenericEvent = "PerfettoGenericEvent";
         public const string CpuSchedEvent = "PerfettoCpuSchedEvent";
+        public const string LogcatEvent = "PerfettoLogcatEvent";
 
         // Path from source parser to example data cooker. This is the path
         // that is used to programatically access the data cooker's data outputs,
@@ -52,10 +56,14 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.ProcessCookerId);
         public static readonly DataCookerPath SchedSliceCookerPath =
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.SchedSliceCookerId);
+        public static readonly DataCookerPath AndroidLogCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.AndroidLogCookerId);
 
         public static readonly DataCookerPath GenericEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.GenericEventCookerId);
         public static readonly DataCookerPath CpuSchedEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.CpuSchedEventCookerId);
+        public static readonly DataCookerPath LogcatEventCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.LogcatEventCookerId);
     }
 }

--- a/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
+++ b/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
@@ -50,10 +50,7 @@ namespace PerfettoCds
         public const string FtraceEvent = "PerfettoFtraceEvent";
         public const string CpuFrequencyEvent = "PerfettoCpuFrequencyEvent";
 
-        // Path from source parser to example data cooker. This is the path
-        // that is used to programatically access the data cooker's data outputs,
-        // and can be created by external binaries by just knowing the
-        // parser and cooker IDs defined above
+        // Paths for source cookers
         public static readonly DataCookerPath SliceCookerPath =
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.SliceCookerId);
         public static readonly DataCookerPath ArgCookerPath =
@@ -75,6 +72,7 @@ namespace PerfettoCds
         public static readonly DataCookerPath CpuCounterTrackCookerPath =
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.CpuCounterTrackCookerId);
 
+        // Paths for composite cookers
         public static readonly DataCookerPath GenericEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.GenericEventCookerId);
         public static readonly DataCookerPath CpuSchedEventCookerPath =

--- a/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
+++ b/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
@@ -20,11 +20,13 @@ namespace PerfettoCds
         public const string ProcessCookerId = "PerfettoProcessCooker";
         public const string SchedSliceCookerId = "PerfettoSchedSliceCooker";
         public const string AndroidLogCookerId = "PerfettoAndroidLogCooker";
+        public const string RawCookerId = "PerfettoRawCooker";
 
         // ID for composite data cookers
         public const string GenericEventCookerId = "PerfettoGenericEventCooker";
         public const string CpuSchedEventCookerId = "PerfettoCpuSchedEventCooker";
         public const string LogcatEventCookerId = "PerfettoLogcatEventCooker";
+        public const string FtraceEventCookerId = "PerfettoFtraceEventCooker";
 
         // Events for source cookers
         public const string SliceEvent = PerfettoSliceEvent.Key;
@@ -34,11 +36,13 @@ namespace PerfettoCds
         public const string ProcessEvent = PerfettoProcessEvent.Key;
         public const string SchedSliceEvent = PerfettoSchedSliceEvent.Key;
         public const string AndroidLogEvent = PerfettoAndroidLogEvent.Key;
+        public const string RawEvent = PerfettoRawEvent.Key;
 
         // Output events for composite cookers
         public const string GenericEvent = "PerfettoGenericEvent";
         public const string CpuSchedEvent = "PerfettoCpuSchedEvent";
         public const string LogcatEvent = "PerfettoLogcatEvent";
+        public const string FtraceEvent = "PerfettoFtraceEvent";
 
         // Path from source parser to example data cooker. This is the path
         // that is used to programatically access the data cooker's data outputs,
@@ -58,6 +62,8 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.SchedSliceCookerId);
         public static readonly DataCookerPath AndroidLogCookerPath =
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.AndroidLogCookerId);
+        public static readonly DataCookerPath RawCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.RawCookerId);
 
         public static readonly DataCookerPath GenericEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.GenericEventCookerId);
@@ -65,5 +71,7 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.CpuSchedEventCookerId);
         public static readonly DataCookerPath LogcatEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.LogcatEventCookerId);
+        public static readonly DataCookerPath FtraceEventCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.FtraceEventCookerId);
     }
 }

--- a/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
+++ b/PerfettoCds/Pipeline/PerfettoPluginConstants.cs
@@ -21,12 +21,15 @@ namespace PerfettoCds
         public const string SchedSliceCookerId = "PerfettoSchedSliceCooker";
         public const string AndroidLogCookerId = "PerfettoAndroidLogCooker";
         public const string RawCookerId = "PerfettoRawCooker";
+        public const string CounterCookerId = "PerfettoCounterCooker";
+        public const string CpuCounterTrackCookerId = "PerfettoCpuCounterTrackCooker";
 
         // ID for composite data cookers
         public const string GenericEventCookerId = "PerfettoGenericEventCooker";
         public const string CpuSchedEventCookerId = "PerfettoCpuSchedEventCooker";
         public const string LogcatEventCookerId = "PerfettoLogcatEventCooker";
         public const string FtraceEventCookerId = "PerfettoFtraceEventCooker";
+        public const string CpuFrequencyEventCookerId = "PerfettoCpuFrequencyEventCooker";
 
         // Events for source cookers
         public const string SliceEvent = PerfettoSliceEvent.Key;
@@ -37,12 +40,15 @@ namespace PerfettoCds
         public const string SchedSliceEvent = PerfettoSchedSliceEvent.Key;
         public const string AndroidLogEvent = PerfettoAndroidLogEvent.Key;
         public const string RawEvent = PerfettoRawEvent.Key;
+        public const string CounterEvent = PerfettoCounterEvent.Key;
+        public const string CpuCounterTrackEvent = PerfettoCpuCounterTrackEvent.Key;
 
         // Output events for composite cookers
         public const string GenericEvent = "PerfettoGenericEvent";
         public const string CpuSchedEvent = "PerfettoCpuSchedEvent";
         public const string LogcatEvent = "PerfettoLogcatEvent";
         public const string FtraceEvent = "PerfettoFtraceEvent";
+        public const string CpuFrequencyEvent = "PerfettoCpuFrequencyEvent";
 
         // Path from source parser to example data cooker. This is the path
         // that is used to programatically access the data cooker's data outputs,
@@ -64,6 +70,10 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.AndroidLogCookerId);
         public static readonly DataCookerPath RawCookerPath =
             new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.RawCookerId);
+        public static readonly DataCookerPath CounterCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.CounterCookerId);
+        public static readonly DataCookerPath CpuCounterTrackCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.ParserId, PerfettoPluginConstants.CpuCounterTrackCookerId);
 
         public static readonly DataCookerPath GenericEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.GenericEventCookerId);
@@ -73,5 +83,8 @@ namespace PerfettoCds
             new DataCookerPath(PerfettoPluginConstants.LogcatEventCookerId);
         public static readonly DataCookerPath FtraceEventCookerPath =
             new DataCookerPath(PerfettoPluginConstants.FtraceEventCookerId);
+        public static readonly DataCookerPath CpuFrequencyEventCookerPath =
+            new DataCookerPath(PerfettoPluginConstants.CpuFrequencyEventCookerId);
+
     }
 }

--- a/PerfettoCds/Pipeline/PerfettoSourceParser.cs
+++ b/PerfettoCds/Pipeline/PerfettoSourceParser.cs
@@ -112,7 +112,9 @@ namespace PerfettoCds
                     new PerfettoProcessEvent(),
                     new PerfettoSchedSliceEvent(),
                     new PerfettoAndroidLogEvent(),
-                    new PerfettoRawEvent()
+                    new PerfettoRawEvent(),
+                    new PerfettoCpuCounterTrackEvent(),
+                    new PerfettoCounterEvent()
                 };
 
                 // Increment progress for each table queried.

--- a/PerfettoCds/Pipeline/PerfettoSourceParser.cs
+++ b/PerfettoCds/Pipeline/PerfettoSourceParser.cs
@@ -111,6 +111,7 @@ namespace PerfettoCds
                     new PerfettoThreadEvent(),
                     new PerfettoProcessEvent(),
                     new PerfettoSchedSliceEvent(),
+                    new PerfettoAndroidLogEvent()
                 };
 
                 // Increment progress for each table queried.

--- a/PerfettoCds/Pipeline/PerfettoSourceParser.cs
+++ b/PerfettoCds/Pipeline/PerfettoSourceParser.cs
@@ -111,7 +111,8 @@ namespace PerfettoCds
                     new PerfettoThreadEvent(),
                     new PerfettoProcessEvent(),
                     new PerfettoSchedSliceEvent(),
-                    new PerfettoAndroidLogEvent()
+                    new PerfettoAndroidLogEvent(),
+                    new PerfettoRawEvent()
                 };
 
                 // Increment progress for each table queried.

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoAndroidLogCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoAndroidLogCooker.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
+using Microsoft.Performance.SDK.Processing;
+using System.Collections.Generic;
+using System.Threading;
+using PerfettoCds.Pipeline.Events;
+using PerfettoProcessor;
+
+namespace PerfettoCds
+{
+    /// <summary>
+    /// Cooks the data from the Android_Logs table in Perfetto traces
+    /// </summary>
+    public sealed class PerfettoAndroidLogCooker : BaseSourceDataCooker<PerfettoSqlEventKeyed, PerfettoSourceParser, string>
+    {
+        public override string Description => "Processes events from the Android_Logs Perfetto SQL table";
+
+        //
+        //  The data this cooker outputs. Tables or other cookers can query for this data
+        //  via the SDK runtime
+        //
+        [DataOutput]
+        public ProcessedEventData<PerfettoAndroidLogEvent> AndroidLogEvents { get; }
+
+        // Instructs runtime to only send events with the given keys this data cooker
+        public override ReadOnlyHashSet<string> DataKeys =>
+            new ReadOnlyHashSet<string>(new HashSet<string> { PerfettoPluginConstants.AndroidLogEvent });
+
+
+        public PerfettoAndroidLogCooker() : base(PerfettoPluginConstants.AndroidLogCookerPath)
+        {
+            this.AndroidLogEvents = new ProcessedEventData<PerfettoAndroidLogEvent>();
+        }
+
+        public override DataProcessingResult CookDataElement(PerfettoSqlEventKeyed perfettoEvent, PerfettoSourceParser context, CancellationToken cancellationToken)
+        {
+            this.AndroidLogEvents.AddEvent((PerfettoAndroidLogEvent)perfettoEvent.SqlEvent);
+
+            return DataProcessingResult.Processed;
+        }
+
+        public override void EndDataCooking(CancellationToken cancellationToken)
+        {
+            base.EndDataCooking(cancellationToken);
+            this.AndroidLogEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCounterCooker.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
+using Microsoft.Performance.SDK.Processing;
+using System.Collections.Generic;
+using System.Threading;
+using PerfettoCds.Pipeline.Events;
+using PerfettoProcessor;
+
+namespace PerfettoCds
+{
+    /// <summary>
+    /// Cooks the data from the Counter table in Perfetto traces
+    /// </summary>
+    public sealed class PerfettoCounterCooker : BaseSourceDataCooker<PerfettoSqlEventKeyed, PerfettoSourceParser, string>
+    {
+        public override string Description => "Processes events from the counter Perfetto SQL table";
+
+        //
+        //  The data this cooker outputs. Tables or other cookers can query for this data
+        //  via the SDK runtime
+        //
+        [DataOutput]
+        public ProcessedEventData<PerfettoCounterEvent> CounterEvents { get; }
+
+        // Instructs runtime to only send events with the given keys this data cooker
+        public override ReadOnlyHashSet<string> DataKeys =>
+            new ReadOnlyHashSet<string>(new HashSet<string> { PerfettoPluginConstants.CounterEvent });
+
+        public PerfettoCounterCooker() : base(PerfettoPluginConstants.CounterCookerPath)
+        {
+            this.CounterEvents = new ProcessedEventData<PerfettoCounterEvent>();
+        }
+
+        public override DataProcessingResult CookDataElement(PerfettoSqlEventKeyed perfettoEvent, PerfettoSourceParser context, CancellationToken cancellationToken)
+        {
+            this.CounterEvents.AddEvent((PerfettoCounterEvent)perfettoEvent.SqlEvent);
+
+            return DataProcessingResult.Processed;
+        }
+
+        public override void EndDataCooking(CancellationToken cancellationToken)
+        {
+            base.EndDataCooking(cancellationToken);
+            this.CounterEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCpuCounterTrack.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoCpuCounterTrack.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
+using Microsoft.Performance.SDK.Processing;
+using System.Collections.Generic;
+using System.Threading;
+using PerfettoCds.Pipeline.Events;
+using PerfettoProcessor;
+
+namespace PerfettoCds
+{
+    /// <summary>
+    /// Cooks the data from the CpuCounterTrack table in Perfetto traces
+    /// </summary>
+    public sealed class PerfettoCpuCounterTrackCooker : BaseSourceDataCooker<PerfettoSqlEventKeyed, PerfettoSourceParser, string>
+    {
+        public override string Description => "Processes events from the CpuCounterTrack Perfetto SQL table";
+
+        //
+        //  The data this cooker outputs. Tables or other cookers can query for this data
+        //  via the SDK runtime
+        //
+        [DataOutput]
+        public ProcessedEventData<PerfettoCpuCounterTrackEvent> CpuCounterTrackEvents { get; }
+
+        // Instructs runtime to only send events with the given keys this data cooker
+        public override ReadOnlyHashSet<string> DataKeys =>
+            new ReadOnlyHashSet<string>(new HashSet<string> { PerfettoPluginConstants.CpuCounterTrackEvent });
+
+        public PerfettoCpuCounterTrackCooker() : base(PerfettoPluginConstants.CpuCounterTrackCookerPath)
+        {
+            this.CpuCounterTrackEvents = new ProcessedEventData<PerfettoCpuCounterTrackEvent>();
+        }
+
+        public override DataProcessingResult CookDataElement(PerfettoSqlEventKeyed perfettoEvent, PerfettoSourceParser context, CancellationToken cancellationToken)
+        {
+            this.CpuCounterTrackEvents.AddEvent((PerfettoCpuCounterTrackEvent)perfettoEvent.SqlEvent);
+
+            return DataProcessingResult.Processed;
+        }
+
+        public override void EndDataCooking(CancellationToken cancellationToken)
+        {
+            base.EndDataCooking(cancellationToken);
+            this.CpuCounterTrackEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/SourceDataCookers/PerfettoRawCooker.cs
+++ b/PerfettoCds/Pipeline/SourceDataCookers/PerfettoRawCooker.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK;
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Extensibility.DataCooking;
+using Microsoft.Performance.SDK.Extensibility.DataCooking.SourceDataCooking;
+using Microsoft.Performance.SDK.Processing;
+using System.Collections.Generic;
+using System.Threading;
+using PerfettoCds.Pipeline.Events;
+using PerfettoProcessor;
+
+namespace PerfettoCds
+{
+    /// <summary>
+    /// Cooks the data from the Raw table in Perfetto traces
+    /// </summary>
+    public sealed class PerfettoRawCooker : BaseSourceDataCooker<PerfettoSqlEventKeyed, PerfettoSourceParser, string>
+    {
+        public override string Description => "Processes events from the Raw Perfetto SQL table";
+
+        //
+        //  The data this cooker outputs. Tables or other cookers can query for this data
+        //  via the SDK runtime
+        //
+        [DataOutput]
+        public ProcessedEventData<PerfettoRawEvent> RawEvents { get; }
+
+        // Instructs runtime to only send events with the given keys this data cooker
+        public override ReadOnlyHashSet<string> DataKeys =>
+            new ReadOnlyHashSet<string>(new HashSet<string> { PerfettoPluginConstants.RawEvent });
+
+
+        public PerfettoRawCooker() : base(PerfettoPluginConstants.RawCookerPath)
+        {
+            this.RawEvents = new ProcessedEventData<PerfettoRawEvent>();
+        }
+
+        public override DataProcessingResult CookDataElement(PerfettoSqlEventKeyed perfettoEvent, PerfettoSourceParser context, CancellationToken cancellationToken)
+        {
+            this.RawEvents.AddEvent((PerfettoRawEvent)perfettoEvent.SqlEvent);
+
+            return DataProcessingResult.Processed;
+        }
+
+        public override void EndDataCooking(CancellationToken cancellationToken)
+        {
+            base.EndDataCooking(cancellationToken);
+            this.RawEvents.FinalizeData();
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Processing;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Diagnostics.CodeAnalysis;
+using PerfettoCds.Pipeline.DataOutput;
+using Microsoft.Performance.SDK;
+using PerfettoCds.Pipeline.DataCookers;
+using System.Linq;
+
+namespace PerfettoCds.Pipeline.Tables
+{
+    [Table]
+    public class PerfettoCpuFrequencyTable
+    {
+        public static TableDescriptor TableDescriptor => new TableDescriptor(
+            Guid.Parse("{5b9689d4-617c-484c-9b0a-c7242565ec13}"),
+            "Perfetto CPU Frequency Events",
+            "Displays CPU scheduling events for processes and threads", // TODO
+            "Perfetto",
+            requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuFrequencyEventCookerPath }
+        );
+
+        private static readonly ColumnConfiguration CpuNumColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{cae82fa3-65c6-43b3-8fc8-2e94c17840bd}"), "CpuNumber", "CPU number"),
+            new UIHints { Width = 210, SortOrder = SortOrder.Ascending });
+
+        private static readonly ColumnConfiguration CpuFrequencyColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{cb753d1a-2c97-414a-9985-06509b6f8ba3}"), "CpuFrequency", "CPU frequency"),
+            new UIHints 
+            { 
+                Width = 210,
+                AggregationMode = AggregationMode.Max,
+            });
+
+        private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{196f823d-646c-4bd2-a263-3fb2c5110f74}"), "StartTimestamp", "Start timestamp for the frequency sample"),
+            new UIHints { Width = 120 });
+
+        private static readonly ColumnConfiguration DurationColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{d42adc27-b3d4-41af-8917-baee8d9f0f21}"), "Duration", "Start timestamp for the frequency sample"),
+            new UIHints { Width = 120 });
+
+        private static readonly ColumnConfiguration CpuStateColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{009c2448-eec0-47b4-a6fe-6ef19ab136f7}"), "CpuState", "CPU state for the frequency sample"),
+            new UIHints { Width = 120 });
+
+        private static readonly ColumnConfiguration IsIdleColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{1b06c328-0d33-49bb-a1fc-381a4b447493}"), "IsIdle", "TODO"),
+            new UIHints { Width = 120 });
+
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
+        {
+            // Get data from the cooker
+            var events = tableData.QueryOutput<ProcessedEventData<PerfettoCpuFrequencyEvent>>(
+                new DataOutputPath(PerfettoPluginConstants.CpuFrequencyEventCookerPath, nameof(PerfettoCpuFrequencyEventCooker.CpuFrequencyEvents)));
+
+            // Start construction of the column order. Pivot on process and thread
+            List<ColumnConfiguration> allColumns = new List<ColumnConfiguration>()
+            {
+                CpuNumColumn,
+                TableConfiguration.PivotColumn, // Columns before this get pivotted on
+                StartTimestampColumn,
+                CpuStateColumn,
+                DurationColumn,
+                IsIdleColumn,
+                TableConfiguration.GraphColumn, // Columns after this get graphed
+                CpuFrequencyColumn
+            };
+
+            var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
+            var baseProjection = Projection.Index(events);
+
+            tableGenerator.AddColumn(CpuNumColumn, baseProjection.Compose(x => x.CpuNum));
+            tableGenerator.AddColumn(CpuFrequencyColumn, baseProjection.Compose(x => x.CpuFrequency));
+            tableGenerator.AddColumn(StartTimestampColumn, baseProjection.Compose(x => x.StartTimestamp));
+            tableGenerator.AddColumn(CpuStateColumn, baseProjection.Compose(x => x.Name));
+            tableGenerator.AddColumn(DurationColumn, baseProjection.Compose(x => x.Duration));
+            tableGenerator.AddColumn(IsIdleColumn, baseProjection.Compose(x => x.IsIdle));
+
+            var tableConfig = new TableConfiguration("Perfetto CPU Scheduling")
+            {
+                Columns = allColumns,
+                Layout = TableLayoutStyle.GraphAndTable,
+                ChartType = ChartType.StackedLine
+            };
+            tableConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+            tableConfig.AddColumnRole(ColumnRole.ResourceId, CpuNumColumn);
+            tableConfig.AddColumnRole(ColumnRole.Duration, DurationColumn);
+
+            tableBuilder.AddTableConfiguration(tableConfig).SetDefaultTableConfiguration(tableConfig);
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
@@ -29,7 +29,7 @@ namespace PerfettoCds.Pipeline.Tables
             new UIHints { Width = 210, SortOrder = SortOrder.Ascending });
 
         private static readonly ColumnConfiguration CpuFrequencyColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{cb753d1a-2c97-414a-9985-06509b6f8ba3}"), "CpuFrequency", "Current frequency for this CPU"),
+            new ColumnMetadata(new Guid("{cb753d1a-2c97-414a-9985-06509b6f8ba3}"), "CpuFrequency(Hz)", "Current frequency for this CPU. When idle, displays 0"),
             new UIHints 
             { 
                 Width = 210,

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuFrequencyTable.cs
@@ -19,7 +19,7 @@ namespace PerfettoCds.Pipeline.Tables
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{5b9689d4-617c-484c-9b0a-c7242565ec13}"),
             "Perfetto CPU Frequency Events",
-            "Displays CPU frequency scaling events and idle states for CPUs",
+            "Displays CPU frequency scaling events and idle states for CPUs. Idle CPUs show a frequency of 0.",
             "Perfetto",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.CpuFrequencyEventCookerPath }
         );

--- a/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoCpuSchedTable.cs
@@ -62,8 +62,6 @@ namespace PerfettoCds.Pipeline.Tables
             var events = tableData.QueryOutput<ProcessedEventData<PerfettoCpuSchedEvent>>(
                 new DataOutputPath(PerfettoPluginConstants.CpuSchedEventCookerPath, nameof(PerfettoCpuSchedEventCooker.CpuSchedEvents)));
 
-            var test = events.OrderBy(x => x.Cpu);
-
             // Start construction of the column order. Pivot on process and thread
             List<ColumnConfiguration> allColumns = new List<ColumnConfiguration>()
             {

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -4,12 +4,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
 using PerfettoCds.Pipeline.DataCookers;
-using PerfettoCds.Utilities;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.Tables
 {

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -13,59 +13,55 @@ using PerfettoCds.Pipeline.DataCookers;
 namespace PerfettoCds.Pipeline.Tables
 {
     [Table]
-    public class PerfettoLogcatEventTable
+    public class PerfettoFtraceEventTable
     {
         // Set some sort of max to prevent ridiculous field counts
         public const int AbsoluteMaxFields = 20;
 
         public static TableDescriptor TableDescriptor => new TableDescriptor(
-            Guid.Parse("{1b25fe8d-887c-4de9-850f-284eb4c28ad7}"),
-            "Perfetto Logcat Events",
-            "All logcat events in the Perfetto trace",
+            Guid.Parse("{96beb7a0-5a9e-4713-b1f7-4ee74d27851c}"),
+            "Perfetto Ftrace Events",
+            "All Ftrace events in the Perfetto trace",
             "Perfetto",
-            requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.LogcatEventCookerPath }
+            requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.FtraceEventCookerPath }
         );
 
         // TODO update descriptions
         private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{01649d8a-6d7b-4024-a07b-b5c1adb6e358}"), "StartTimestamp", "Start timestamp of the event"),
+            new ColumnMetadata(new Guid("{e9675de9-4a76-4bba-a387-169c7ee38425}"), "StartTimestamp", "Start timestamp of the event"),
             new UIHints { Width = 180 });
 
         private static readonly ColumnConfiguration ProcessNameColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{c149eeb0-8f9d-41b1-9513-728bea20535d}"), "ProcessName", "Name of the process that logged the event"),
+            new ColumnMetadata(new Guid("{8027964f-4c41-4309-ada1-b9a40d685b24}"), "ProcessName", "Name of the process that logged the event"),
             new UIHints { Width = 210 });
         
         private static readonly ColumnConfiguration ThreadNameColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{8b0c4b2a-675e-40d2-9c34-164f6a4751f7}"), "ThreadName", "Name of the thread that logged the event"),
+            new ColumnMetadata(new Guid("{276ab2ad-722c-4a1b-8d9f-dc7b562d3a5c}"), "ThreadName", "Name of the thread that logged the event"),
             new UIHints { Width = 210 });
 
-        private static readonly ColumnConfiguration PriorityColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{b03c591b-da3d-4866-a762-c44c5017de31}"), "Priority", "Priority of the logcat message"),
+        private static readonly ColumnConfiguration CpuColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{16b7cf75-de7c-4cb7-9d72-3302a1cdf54f}"), "Cpu", "CPU"),
             new UIHints { Width = 150 });
 
-        private static readonly ColumnConfiguration TagColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{365a2cd8-1b17-4c52-a23a-35ad8e0b126a}"), "Tag", "Logcat message tag"),
+        private static readonly ColumnConfiguration NameColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{ea581f83-b632-4b5b-9a89-844994f497ca}"), "Name", "Name of the Ftrace event"),
             new UIHints { Width = 120 });
-
-        private static readonly ColumnConfiguration MessageColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{28a51601-ccdc-4a9a-b484-1e85dad75ea5}"), "Message", "Logcat message"),
-            new UIHints { Width = 300 });
 
 
         public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
         {
             // Get data from the cooker
-            var events = tableData.QueryOutput<ProcessedEventData<PerfettoLogcatEvent>>(
-                new DataOutputPath(PerfettoPluginConstants.LogcatEventCookerPath, nameof(PerfettoLogcatEventCooker.LogcatEvents)));
+            var events = tableData.QueryOutput<ProcessedEventData<PerfettoFtraceEvent>>(
+                new DataOutputPath(PerfettoPluginConstants.FtraceEventCookerPath, nameof(PerfettoFtraceEventCooker.FtraceEvents)));
 
             // Start construction of the column order. Pivot on process and thread
             List<ColumnConfiguration> allColumns = new List<ColumnConfiguration>() 
             {
+                CpuColumn,
+                TableConfiguration.PivotColumn, // Columns before this get pivotted
                 ProcessNameColumn,
                 ThreadNameColumn,
-                TagColumn,
-                MessageColumn,
-                PriorityColumn,
+                NameColumn,
                 TableConfiguration.GraphColumn, // Columns after this get graphed
                 StartTimestampColumn
             };
@@ -76,9 +72,8 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(StartTimestampColumn, baseProjection.Compose(x => x.StartTimestamp));
             tableGenerator.AddColumn(ProcessNameColumn, baseProjection.Compose(x => x.ProcessName));
             tableGenerator.AddColumn(ThreadNameColumn, baseProjection.Compose(x => x.ThreadName));
-            tableGenerator.AddColumn(PriorityColumn, baseProjection.Compose(x => x.Priority));
-            tableGenerator.AddColumn(TagColumn, baseProjection.Compose(x => x.Tag));
-            tableGenerator.AddColumn(MessageColumn, baseProjection.Compose(x => x.Message));
+            tableGenerator.AddColumn(CpuColumn, baseProjection.Compose(x => x.Cpu));
+            tableGenerator.AddColumn(NameColumn, baseProjection.Compose(x => x.Name));
 
             var tableConfig = new TableConfiguration("Perfetto Logcat Events")
             {

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -50,6 +50,11 @@ namespace PerfettoCds.Pipeline.Tables
 
         public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
         {
+            // We dynamically adjust the column headers
+            // This is the max number of fields we can expect for this table
+            int maxFieldCount = Math.Min(AbsoluteMaxFields, tableData.QueryOutput<int>(
+                new DataOutputPath(PerfettoPluginConstants.FtraceEventCookerPath, nameof(PerfettoFtraceEventCooker.MaximumEventFieldCount))));
+
             // Get data from the cooker
             var events = tableData.QueryOutput<ProcessedEventData<PerfettoFtraceEvent>>(
                 new DataOutputPath(PerfettoPluginConstants.FtraceEventCookerPath, nameof(PerfettoFtraceEventCooker.FtraceEvents)));
@@ -62,20 +67,67 @@ namespace PerfettoCds.Pipeline.Tables
                 ProcessNameColumn,
                 ThreadNameColumn,
                 NameColumn,
-                TableConfiguration.GraphColumn, // Columns after this get graphed
-                StartTimestampColumn
             };
 
             var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
-            var baseProjection = Projection.Index(events);
+            var eventProjection = new EventProjection<PerfettoFtraceEvent>(events);
 
-            tableGenerator.AddColumn(StartTimestampColumn, baseProjection.Compose(x => x.StartTimestamp));
-            tableGenerator.AddColumn(ProcessNameColumn, baseProjection.Compose(x => x.ProcessName));
-            tableGenerator.AddColumn(ThreadNameColumn, baseProjection.Compose(x => x.ThreadName));
-            tableGenerator.AddColumn(CpuColumn, baseProjection.Compose(x => x.Cpu));
-            tableGenerator.AddColumn(NameColumn, baseProjection.Compose(x => x.Name));
+            var processNameColumn = new BaseDataColumn<string>(
+                ProcessNameColumn,
+                eventProjection.Compose((ftraceEvent) => ftraceEvent.ProcessName));
+            tableGenerator.AddColumn(processNameColumn);
 
-            var tableConfig = new TableConfiguration("Perfetto Logcat Events")
+            var threadNameColumn = new BaseDataColumn<string>(
+                ThreadNameColumn,
+                eventProjection.Compose((ftraceEvent) => ftraceEvent.ThreadName));
+            tableGenerator.AddColumn(threadNameColumn);
+
+            var startTimestampColumn = new BaseDataColumn<Timestamp>(
+                StartTimestampColumn,
+                eventProjection.Compose((ftraceEvent) => ftraceEvent.StartTimestamp));
+            tableGenerator.AddColumn(startTimestampColumn);
+
+            var cpuColumn = new BaseDataColumn<long>(
+                CpuColumn,
+                eventProjection.Compose((ftraceEvent) => ftraceEvent.Cpu));
+            tableGenerator.AddColumn(cpuColumn);
+
+            var nameColumn = new BaseDataColumn<string>(
+                NameColumn,
+                eventProjection.Compose((ftraceEvent) => ftraceEvent.Name));
+            tableGenerator.AddColumn(nameColumn);
+
+            // Add the field columns, with column names depending on the given event
+            for (int index = 0; index < maxFieldCount; index++)
+            {
+                var colIndex = index;  // This seems unncessary but causes odd runtime behavior if not done this way. Compiler is confused perhaps because w/o this func will index=event.FieldNames.Count every time. index is passed as ref but colIndex as value into func
+                string fieldName = "Field " + (colIndex + 1);
+
+                var eventFieldNameProjection = eventProjection.Compose((ftraceEvent) => colIndex < ftraceEvent.ArgKeys.Count ? ftraceEvent.ArgKeys[colIndex] : string.Empty);
+
+                // generate a column configuration
+                var fieldColumnConfiguration = new ColumnConfiguration(
+                        new ColumnMetadata(GenerateGuidFromName(fieldName), fieldName, eventFieldNameProjection, fieldName),
+                        new UIHints
+                        {
+                            IsVisible = true,
+                            Width = 150,
+                            TextAlignment = TextAlignment.Left,
+                        });
+
+                // Add this column to the column order
+                allColumns.Add(fieldColumnConfiguration);
+
+                var eventFieldAsStringProjection = eventProjection.Compose((ftraceEvent) => colIndex < ftraceEvent.Values.Count ? ftraceEvent.Values[colIndex] : string.Empty);
+
+                tableGenerator.AddColumn(fieldColumnConfiguration, eventFieldAsStringProjection);
+            }
+
+            // Finish the column order with the timestamp columned being graphed
+            allColumns.Add(TableConfiguration.GraphColumn); // Columns after this get graphed
+            allColumns.Add(StartTimestampColumn);
+
+            var tableConfig = new TableConfiguration("Perfetto Ftrace Events")
             {
                 Columns = allColumns,
                 Layout = TableLayoutStyle.GraphAndTable
@@ -83,6 +135,67 @@ namespace PerfettoCds.Pipeline.Tables
             tableConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
 
             tableBuilder.AddTableConfiguration(tableConfig).SetDefaultTableConfiguration(tableConfig);
+        }
+
+        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]
+        private static Guid GenerateGuidFromName(string name)
+        {
+            // The algorithm below is following the guidance of http://www.ietf.org/rfc/rfc4122.txt
+            // Create a blob containing a 16 byte number representing the namespace
+            // followed by the unicode bytes in the name.  
+            var bytes = new byte[name.Length * 2 + 16];
+            uint namespace1 = 0x482C2DB2;
+            uint namespace2 = 0xC39047c8;
+            uint namespace3 = 0x87F81A15;
+            uint namespace4 = 0xBFC130FB;
+            // Write the bytes most-significant byte first.  
+            for (int i = 3; 0 <= i; --i)
+            {
+                bytes[i] = (byte)namespace1;
+                namespace1 >>= 8;
+                bytes[i + 4] = (byte)namespace2;
+                namespace2 >>= 8;
+                bytes[i + 8] = (byte)namespace3;
+                namespace3 >>= 8;
+                bytes[i + 12] = (byte)namespace4;
+                namespace4 >>= 8;
+            }
+            // Write out  the name, most significant byte first
+            for (int i = 0; i < name.Length; i++)
+            {
+                bytes[2 * i + 16 + 1] = (byte)name[i];
+                bytes[2 * i + 16] = (byte)(name[i] >> 8);
+            }
+
+            // Compute the Sha1 hash 
+            var sha1 = SHA1.Create();
+            byte[] hash = sha1.ComputeHash(bytes);
+
+            // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)
+            int a = (((((hash[3] << 8) + hash[2]) << 8) + hash[1]) << 8) + hash[0];
+            short b = (short)((hash[5] << 8) + hash[4]);
+            short c = (short)((hash[7] << 8) + hash[6]);
+
+            c = (short)((c & 0x0FFF) | 0x5000);   // Set high 4 bits of octet 7 to 5, as per RFC 4122
+            Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
+            return guid;
+        }
+
+        public struct EventProjection<T>
+            : IProjection<int, T>
+        {
+            private readonly ProcessedEventData<T> events;
+
+            public EventProjection(ProcessedEventData<T> events)
+            {
+                this.events = events;
+            }
+
+            public Type SourceType => typeof(int);
+
+            public Type ResultType => typeof(T);
+
+            public T this[int value] => this.events[(uint)value];
         }
     }
 }

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -39,7 +39,7 @@ namespace PerfettoCds.Pipeline.Tables
 
         private static readonly ColumnConfiguration CpuColumn = new ColumnConfiguration(
             new ColumnMetadata(new Guid("{16b7cf75-de7c-4cb7-9d72-3302a1cdf54f}"), "CpuCore", "Specific CPU core"),
-            new UIHints { Width = 150 });
+            new UIHints { Width = 150, SortOrder = SortOrder.Ascending });
 
         private static readonly ColumnConfiguration NameColumn = new ColumnConfiguration(
             new ColumnMetadata(new Guid("{ea581f83-b632-4b5b-9a89-844994f497ca}"), "Name", "Name of the Ftrace event"),

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -27,7 +27,6 @@ namespace PerfettoCds.Pipeline.Tables
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.FtraceEventCookerPath }
         );
 
-        // TODO update descriptions
         private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
             new ColumnMetadata(new Guid("{e9675de9-4a76-4bba-a387-169c7ee38425}"), "StartTimestamp", "Start timestamp of the event"),
             new UIHints { Width = 180 });
@@ -41,7 +40,7 @@ namespace PerfettoCds.Pipeline.Tables
             new UIHints { Width = 210 });
 
         private static readonly ColumnConfiguration CpuColumn = new ColumnConfiguration(
-            new ColumnMetadata(new Guid("{16b7cf75-de7c-4cb7-9d72-3302a1cdf54f}"), "Cpu", "CPU"),
+            new ColumnMetadata(new Guid("{16b7cf75-de7c-4cb7-9d72-3302a1cdf54f}"), "CpuCore", "Specific CPU core"),
             new UIHints { Width = 150 });
 
         private static readonly ColumnConfiguration NameColumn = new ColumnConfiguration(

--- a/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoFtraceEventTable.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
 using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Utilities;
 
 namespace PerfettoCds.Pipeline.Tables
 {
@@ -107,7 +108,7 @@ namespace PerfettoCds.Pipeline.Tables
 
                 // generate a column configuration
                 var fieldColumnConfiguration = new ColumnConfiguration(
-                        new ColumnMetadata(GenerateGuidFromName(fieldName), fieldName, eventFieldNameProjection, fieldName),
+                        new ColumnMetadata(Common.GenerateGuidFromName(fieldName), fieldName, eventFieldNameProjection, fieldName),
                         new UIHints
                         {
                             IsVisible = true,
@@ -135,67 +136,6 @@ namespace PerfettoCds.Pipeline.Tables
             tableConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
 
             tableBuilder.AddTableConfiguration(tableConfig).SetDefaultTableConfiguration(tableConfig);
-        }
-
-        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]
-        private static Guid GenerateGuidFromName(string name)
-        {
-            // The algorithm below is following the guidance of http://www.ietf.org/rfc/rfc4122.txt
-            // Create a blob containing a 16 byte number representing the namespace
-            // followed by the unicode bytes in the name.  
-            var bytes = new byte[name.Length * 2 + 16];
-            uint namespace1 = 0x482C2DB2;
-            uint namespace2 = 0xC39047c8;
-            uint namespace3 = 0x87F81A15;
-            uint namespace4 = 0xBFC130FB;
-            // Write the bytes most-significant byte first.  
-            for (int i = 3; 0 <= i; --i)
-            {
-                bytes[i] = (byte)namespace1;
-                namespace1 >>= 8;
-                bytes[i + 4] = (byte)namespace2;
-                namespace2 >>= 8;
-                bytes[i + 8] = (byte)namespace3;
-                namespace3 >>= 8;
-                bytes[i + 12] = (byte)namespace4;
-                namespace4 >>= 8;
-            }
-            // Write out  the name, most significant byte first
-            for (int i = 0; i < name.Length; i++)
-            {
-                bytes[2 * i + 16 + 1] = (byte)name[i];
-                bytes[2 * i + 16] = (byte)(name[i] >> 8);
-            }
-
-            // Compute the Sha1 hash 
-            var sha1 = SHA1.Create();
-            byte[] hash = sha1.ComputeHash(bytes);
-
-            // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)
-            int a = (((((hash[3] << 8) + hash[2]) << 8) + hash[1]) << 8) + hash[0];
-            short b = (short)((hash[5] << 8) + hash[4]);
-            short c = (short)((hash[7] << 8) + hash[6]);
-
-            c = (short)((c & 0x0FFF) | 0x5000);   // Set high 4 bits of octet 7 to 5, as per RFC 4122
-            Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
-            return guid;
-        }
-
-        public struct EventProjection<T>
-            : IProjection<int, T>
-        {
-            private readonly ProcessedEventData<T> events;
-
-            public EventProjection(ProcessedEventData<T> events)
-            {
-                this.events = events;
-            }
-
-            public Type SourceType => typeof(int);
-
-            public Type ResultType => typeof(T);
-
-            public T this[int value] => this.events[(uint)value];
         }
     }
 }

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -4,12 +4,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
 using PerfettoCds.Pipeline.DataCookers;
-using PerfettoCds.Utilities;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.Tables
 {

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
 using PerfettoCds.Pipeline.DataCookers;
+using PerfettoCds.Utilities;
 
 namespace PerfettoCds.Pipeline.Tables
 {
@@ -83,7 +84,7 @@ namespace PerfettoCds.Pipeline.Tables
             };
 
             var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
-            var genericEventProjection = new GenericEventProjection(events);
+            var genericEventProjection = new EventProjection<PerfettoGenericEvent>(events);
 
             // Add all the data projections
             var processNameColumn = new BaseDataColumn<string>(
@@ -136,7 +137,7 @@ namespace PerfettoCds.Pipeline.Tables
 
                 // generate a column configuration
                 var fieldColumnConfiguration = new ColumnConfiguration(
-                        new ColumnMetadata(GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
+                        new ColumnMetadata(Common.GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
                         new UIHints
                         {
                             IsVisible = true,
@@ -166,67 +167,6 @@ namespace PerfettoCds.Pipeline.Tables
             tableConfig.AddColumnRole(ColumnRole.Duration, DurationColumn.Metadata.Guid);
 
             tableBuilder.AddTableConfiguration(tableConfig).SetDefaultTableConfiguration(tableConfig);
-        }
-
-        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]
-        private static Guid GenerateGuidFromName(string name)
-        {
-            // The algorithm below is following the guidance of http://www.ietf.org/rfc/rfc4122.txt
-            // Create a blob containing a 16 byte number representing the namespace
-            // followed by the unicode bytes in the name.  
-            var bytes = new byte[name.Length * 2 + 16];
-            uint namespace1 = 0x482C2DB2;
-            uint namespace2 = 0xC39047c8;
-            uint namespace3 = 0x87F81A15;
-            uint namespace4 = 0xBFC130FB;
-            // Write the bytes most-significant byte first.  
-            for (int i = 3; 0 <= i; --i)
-            {
-                bytes[i] = (byte)namespace1;
-                namespace1 >>= 8;
-                bytes[i + 4] = (byte)namespace2;
-                namespace2 >>= 8;
-                bytes[i + 8] = (byte)namespace3;
-                namespace3 >>= 8;
-                bytes[i + 12] = (byte)namespace4;
-                namespace4 >>= 8;
-            }
-            // Write out  the name, most significant byte first
-            for (int i = 0; i < name.Length; i++)
-            {
-                bytes[2 * i + 16 + 1] = (byte)name[i];
-                bytes[2 * i + 16] = (byte)(name[i] >> 8);
-            }
-
-            // Compute the Sha1 hash 
-            var sha1 = SHA1.Create();
-            byte[] hash = sha1.ComputeHash(bytes);
-
-            // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)
-            int a = (((((hash[3] << 8) + hash[2]) << 8) + hash[1]) << 8) + hash[0];
-            short b = (short)((hash[5] << 8) + hash[4]);
-            short c = (short)((hash[7] << 8) + hash[6]);
-
-            c = (short)((c & 0x0FFF) | 0x5000);   // Set high 4 bits of octet 7 to 5, as per RFC 4122
-            Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
-            return guid;
-        }
-
-        public struct GenericEventProjection
-            : IProjection<int, PerfettoGenericEvent>
-        {
-            private readonly ProcessedEventData<PerfettoGenericEvent> genericEvents;
-
-            public GenericEventProjection(ProcessedEventData<PerfettoGenericEvent> genericEvents)
-            {
-                this.genericEvents = genericEvents;
-            }
-
-            public Type SourceType => typeof(int);
-
-            public Type ResultType => typeof(PerfettoGenericEvent);
-
-            public PerfettoGenericEvent this[int value] => this.genericEvents[(uint)value];
         }
     }
 }

--- a/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.Performance.SDK.Extensibility;
+using Microsoft.Performance.SDK.Processing;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Diagnostics.CodeAnalysis;
+using PerfettoCds.Pipeline.DataOutput;
+using Microsoft.Performance.SDK;
+using PerfettoCds.Pipeline.DataCookers;
+
+namespace PerfettoCds.Pipeline.Tables
+{
+    [Table]
+    public class PerfettoLogcatEventTable
+    {
+        // Set some sort of max to prevent ridiculous field counts
+        public const int AbsoluteMaxFields = 20;
+
+        public static TableDescriptor TableDescriptor => new TableDescriptor(
+            Guid.Parse("{1b25fe8d-887c-4de9-850f-284eb4c28ad7}"),
+            "Perfetto Logcat Events",
+            "All app/component events in the Perfetto trace",
+            "Perfetto",
+            requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.LogcatEventCookerPath }
+        );
+
+        // TODO update descriptions
+        private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{01649d8a-6d7b-4024-a07b-b5c1adb6e358}"), "StartTimestamp", "Start timestamp of the event"),
+            new UIHints { Width = 180 });
+
+        private static readonly ColumnConfiguration ProcessNameColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{c149eeb0-8f9d-41b1-9513-728bea20535d}"), "ProcessName", "Name of the process that logged the event"),
+            new UIHints { Width = 210 });
+
+        private static readonly ColumnConfiguration PriorityColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{b03c591b-da3d-4866-a762-c44c5017de31}"), "Priority", "Priority of the logcat message"),
+            new UIHints { Width = 150 });
+
+        private static readonly ColumnConfiguration TagColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{365a2cd8-1b17-4c52-a23a-35ad8e0b126a}"), "Tag", "Logcat message tag"),
+            new UIHints { Width = 120 });
+
+        private static readonly ColumnConfiguration MessageColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{28a51601-ccdc-4a9a-b484-1e85dad75ea5}"), "Message", "Logcat message"),
+            new UIHints { Width = 300 });
+
+
+        public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
+        {
+            // Get data from the cooker
+            var events = tableData.QueryOutput<ProcessedEventData<PerfettoLogcatEvent>>(
+                new DataOutputPath(PerfettoPluginConstants.LogcatEventCookerPath, nameof(PerfettoLogcatEventCooker.LogcatEvents)));
+
+            // Start construction of the column order. Pivot on process and thread
+            List<ColumnConfiguration> allColumns = new List<ColumnConfiguration>() 
+            {
+                ProcessNameColumn,
+                TagColumn,
+                MessageColumn,
+                PriorityColumn,
+                TableConfiguration.GraphColumn, // Columns after this get graphed
+                StartTimestampColumn
+            };
+
+            var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
+            var baseProjection = Projection.Index(events);
+
+            tableGenerator.AddColumn(StartTimestampColumn, baseProjection.Compose(x => x.StartTimestamp));
+            tableGenerator.AddColumn(ProcessNameColumn, baseProjection.Compose(x => x.ProcessName));
+            tableGenerator.AddColumn(PriorityColumn, baseProjection.Compose(x => x.Priority));
+            tableGenerator.AddColumn(TagColumn, baseProjection.Compose(x => x.Tag));
+            tableGenerator.AddColumn(MessageColumn, baseProjection.Compose(x => x.Message));
+
+            var tableConfig = new TableConfiguration("Perfetto Logcat Events")
+            {
+                Columns = allColumns,
+                Layout = TableLayoutStyle.GraphAndTable
+            };
+            tableConfig.AddColumnRole(ColumnRole.StartTime, StartTimestampColumn.Metadata.Guid);
+
+            tableBuilder.AddTableConfiguration(tableConfig).SetDefaultTableConfiguration(tableConfig);
+        }
+    }
+}

--- a/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
@@ -20,9 +20,9 @@ namespace PerfettoCds.Pipeline.Tables
 
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{1b25fe8d-887c-4de9-850f-284eb4c28ad7}"),
-            "Perfetto Logcat Events",
+            "Android Logcat Events",
             "All logcat events/messages in the Perfetto trace",
-            "Perfetto",
+            "Android",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.LogcatEventCookerPath }
         );
 

--- a/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoLogcatEventTable.cs
@@ -21,12 +21,11 @@ namespace PerfettoCds.Pipeline.Tables
         public static TableDescriptor TableDescriptor => new TableDescriptor(
             Guid.Parse("{1b25fe8d-887c-4de9-850f-284eb4c28ad7}"),
             "Perfetto Logcat Events",
-            "All logcat events in the Perfetto trace",
+            "All logcat events/messages in the Perfetto trace",
             "Perfetto",
             requiredDataCookers: new List<DataCookerPath> { PerfettoPluginConstants.LogcatEventCookerPath }
         );
 
-        // TODO update descriptions
         private static readonly ColumnConfiguration StartTimestampColumn = new ColumnConfiguration(
             new ColumnMetadata(new Guid("{01649d8a-6d7b-4024-a07b-b5c1adb6e358}"), "StartTimestamp", "Start timestamp of the event"),
             new UIHints { Width = 180 });

--- a/PerfettoCds/Utilities/Common.cs
+++ b/PerfettoCds/Utilities/Common.cs
@@ -22,7 +22,6 @@ namespace PerfettoCds.Utilities
         public T this[int value] => this.events[(uint)value];
     }
 
-    // TODO Move these into a 
     public class Common
     {
         [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]

--- a/PerfettoCds/Utilities/Common.cs
+++ b/PerfettoCds/Utilities/Common.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Performance.SDK.Processing;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+namespace PerfettoCds.Utilities
+{
+    public struct EventProjection<T>
+    : IProjection<int, T>
+    {
+        private readonly ProcessedEventData<T> events;
+
+        public EventProjection(ProcessedEventData<T> events)
+        {
+            this.events = events;
+        }
+
+        public Type SourceType => typeof(int);
+
+        public Type ResultType => typeof(T);
+
+        public T this[int value] => this.events[(uint)value];
+    }
+
+    // TODO Move these into a 
+    public class Common
+    {
+        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]
+        public static Guid GenerateGuidFromName(string name)
+        {
+            // The algorithm below is following the guidance of http://www.ietf.org/rfc/rfc4122.txt
+            // Create a blob containing a 16 byte number representing the namespace
+            // followed by the unicode bytes in the name.  
+            var bytes = new byte[name.Length * 2 + 16];
+            uint namespace1 = 0x482C2DB2;
+            uint namespace2 = 0xC39047c8;
+            uint namespace3 = 0x87F81A15;
+            uint namespace4 = 0xBFC130FB;
+            // Write the bytes most-significant byte first.  
+            for (int i = 3; 0 <= i; --i)
+            {
+                bytes[i] = (byte)namespace1;
+                namespace1 >>= 8;
+                bytes[i + 4] = (byte)namespace2;
+                namespace2 >>= 8;
+                bytes[i + 8] = (byte)namespace3;
+                namespace3 >>= 8;
+                bytes[i + 12] = (byte)namespace4;
+                namespace4 >>= 8;
+            }
+            // Write out  the name, most significant byte first
+            for (int i = 0; i < name.Length; i++)
+            {
+                bytes[2 * i + 16 + 1] = (byte)name[i];
+                bytes[2 * i + 16] = (byte)(name[i] >> 8);
+            }
+
+            // Compute the Sha1 hash 
+            var sha1 = SHA1.Create();
+            byte[] hash = sha1.ComputeHash(bytes);
+
+            // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)
+            int a = (((((hash[3] << 8) + hash[2]) << 8) + hash[1]) << 8) + hash[0];
+            short b = (short)((hash[5] << 8) + hash[4]);
+            short c = (short)((hash[7] << 8) + hash[6]);
+
+            c = (short)((c & 0x0FFF) | 0x5000);   // Set high 4 bits of octet 7 to 5, as per RFC 4122
+            Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
+            return guid;
+        }
+    }
+}

--- a/PerfettoProcessor/Events/PerfettoAndroidLogEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoAndroidLogEvent.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Perfetto.Protos;
+
+namespace PerfettoProcessor
+{
+    public class PerfettoAndroidLogEvent : PerfettoSqlEvent
+    {
+        public const string Key = "PerfettoAndroidLogEvent";
+
+        public static string SqlQuery = "select ts, prio, tag, msg, utid from android_logs";
+        public long Timestamp { get; set; }
+        public long Priority { get; set; }
+        public string PriorityString { get; set; }
+        public string Tag { get; set; }
+        public string  Message { get; set; }
+        public long Utid { get; set; }
+
+        public override string GetSqlQuery()
+        {
+            return SqlQuery;
+        }
+
+        public override string GetEventKey()
+        {
+            return Key;
+        }
+
+        // Priority codes gathered from AndroidLogPriority in Perfetto repo
+        private static readonly string[] PriorityToString = new string[8] { "Unspecified", "Unusued", "Verbose", "Debug", "Info", "Warn", "Error", "Fatal" };
+
+        public override void ProcessCell(string colName,
+            QueryResult.Types.CellsBatch.Types.CellType cellType,
+            QueryResult.Types.CellsBatch batch,
+            string[] stringCells,
+            CellCounters counters)
+        {
+            var col = colName.ToLower();
+            switch (cellType)
+            {
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellInvalid:
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellNull:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellVarint:
+                    var longVal = batch.VarintCells[counters.IntCounter++];
+                    switch (col)
+                    {
+                        case "utid":
+                            Utid = longVal;
+                            break;
+                        case "ts":
+                            Timestamp = longVal;
+                            break;
+                        case "prio":
+                            Priority = longVal;
+                            if (Priority >= 0 && Priority < PriorityToString.Length)
+                            {
+                                PriorityString = PriorityToString[longVal];
+                            }
+                            else
+                            {
+                                PriorityString = longVal.ToString();
+                            }
+                            break;
+                    }
+
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
+                    var strVal = stringCells[counters.StringCounter++];
+                    switch (col)
+                    {
+                        case "tag":
+                            Tag = strVal;
+                            break;
+                        case "msg":
+                            Message = strVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellBlob:
+                    break;
+                default:
+                    throw new Exception("Unexpected CellType");
+            }
+        }
+    }
+}

--- a/PerfettoProcessor/Events/PerfettoCounterEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoCounterEvent.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Perfetto.Protos;
+
+namespace PerfettoProcessor
+{
+    public class PerfettoCounterEvent : PerfettoSqlEvent
+    {
+        public const string Key = "PerfettoCounterEvent";
+
+        public static string SqlQuery = "select ts, track_id, value from counter";
+        public long Timestamp { get; set; }
+        public long TrackId { get; set; }
+        public double FloatValue { get; set; }
+        public long IntValue { get; set; }
+
+        public override string GetSqlQuery()
+        {
+            return SqlQuery;
+        }
+
+        public override string GetEventKey()
+        {
+            return Key;
+        }
+
+        public override void ProcessCell(string colName,
+            QueryResult.Types.CellsBatch.Types.CellType cellType,
+            QueryResult.Types.CellsBatch batch,
+            string[] stringCells,
+            CellCounters counters)
+        {
+            var col = colName.ToLower();
+            switch (cellType)
+            {
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellInvalid:
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellNull:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellVarint:
+                    var longVal = batch.VarintCells[counters.IntCounter++];
+                    switch (col)
+                    {
+                        case "ts":
+                            Timestamp = longVal;
+                            break;
+                        case "track_id":
+                            TrackId = longVal;
+                            break;
+                        case "value":
+                            IntValue = longVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
+                    var floatVal = batch.Float64Cells[counters.FloatCounter++];
+                    switch (col)
+                    {
+                        case "value":
+                            FloatValue = floatVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellBlob:
+                    break;
+                default:
+                    throw new Exception("Unexpected CellType");
+            }
+        }
+    }
+}

--- a/PerfettoProcessor/Events/PerfettoCpuCounterTrackEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoCpuCounterTrackEvent.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Perfetto.Protos;
+
+namespace PerfettoProcessor
+{
+    public class PerfettoCpuCounterTrackEvent : PerfettoSqlEvent
+    {
+        public const string Key = "PerfettoCpuCounterTrackEvent";
+
+        public static string SqlQuery = "select name, id, cpu from cpu_counter_track";
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public long Cpu { get; set; }
+
+        public override string GetSqlQuery()
+        {
+            return SqlQuery;
+        }
+
+        public override string GetEventKey()
+        {
+            return Key;
+        }
+
+        public override void ProcessCell(string colName,
+            QueryResult.Types.CellsBatch.Types.CellType cellType,
+            QueryResult.Types.CellsBatch batch,
+            string[] stringCells,
+            CellCounters counters)
+        {
+            var col = colName.ToLower();
+            switch (cellType)
+            {
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellInvalid:
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellNull:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellVarint:
+                    var longVal = batch.VarintCells[counters.IntCounter++];
+                    switch (col)
+                    {
+                        case "id":
+                            Id = longVal;
+                            break;
+                        case "cpu":
+                            Cpu = longVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
+                    var strVal = stringCells[counters.StringCounter++];
+                    switch (col)
+                    {
+                        case "name":
+                            Name = strVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellBlob:
+                    break;
+                default:
+                    throw new Exception("Unexpected CellType");
+            }
+        }
+    }
+}

--- a/PerfettoProcessor/Events/PerfettoRawEvent.cs
+++ b/PerfettoProcessor/Events/PerfettoRawEvent.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Perfetto.Protos;
+
+namespace PerfettoProcessor
+{
+    public class PerfettoRawEvent : PerfettoSqlEvent
+    {
+        public const string Key = "PerfettoRawEvent";
+
+        public static string SqlQuery = "select type, ts, name, cpu, utid, arg_set_id from raw";
+        public string Type { get; set; }
+        public long Timestamp { get; set; }
+        public string Name { get; set; }
+        public long Cpu { get; set; }
+        public long Utid { get; set; }
+        public long ArgSetId { get; set; }
+
+
+        public override string GetSqlQuery()
+        {
+            return SqlQuery;
+        }
+
+        public override string GetEventKey()
+        {
+            return Key;
+        }
+
+        public override void ProcessCell(string colName,
+            QueryResult.Types.CellsBatch.Types.CellType cellType,
+            QueryResult.Types.CellsBatch batch,
+            string[] stringCells,
+            CellCounters counters)
+        {
+            var col = colName.ToLower();
+            switch (cellType)
+            {
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellInvalid:
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellNull:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellVarint:
+                    var longVal = batch.VarintCells[counters.IntCounter++];
+                    switch (col)
+                    {
+                        case "utid":
+                            Utid = longVal;
+                            break;
+                        case "ts":
+                            Timestamp = longVal;
+                            break;
+                        case "cpu":
+                            Cpu = longVal;
+                            break;
+                        case "arg_set_id":
+                            ArgSetId = longVal;
+                            break;
+                    }
+
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellFloat64:
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellString:
+                    var strVal = stringCells[counters.StringCounter++];
+                    switch (col)
+                    {
+                        case "type":
+                            Type = strVal;
+                            break;
+                        case "name":
+                            Name = strVal;
+                            break;
+                    }
+                    break;
+                case Perfetto.Protos.QueryResult.Types.CellsBatch.Types.CellType.CellBlob:
+                    break;
+                default:
+                    throw new Exception("Unexpected CellType");
+            }
+        }
+    }
+}

--- a/PerfettoProcessor/PerfettoTraceProcessor.cs
+++ b/PerfettoProcessor/PerfettoTraceProcessor.cs
@@ -264,6 +264,9 @@ namespace PerfettoProcessor
                                 case PerfettoAndroidLogEvent.Key:
                                     ev = new PerfettoAndroidLogEvent();
                                     break;
+                                case PerfettoRawEvent.Key:
+                                    ev = new PerfettoRawEvent();
+                                    break;
                                 default:
                                     throw new Exception("Invalid event type");
                             }

--- a/PerfettoProcessor/PerfettoTraceProcessor.cs
+++ b/PerfettoProcessor/PerfettoTraceProcessor.cs
@@ -267,6 +267,12 @@ namespace PerfettoProcessor
                                 case PerfettoRawEvent.Key:
                                     ev = new PerfettoRawEvent();
                                     break;
+                                case PerfettoCounterEvent.Key:
+                                    ev = new PerfettoCounterEvent();
+                                    break;
+                                case PerfettoCpuCounterTrackEvent.Key:
+                                    ev = new PerfettoCpuCounterTrackEvent();
+                                    break;
                                 default:
                                     throw new Exception("Invalid event type");
                             }

--- a/PerfettoProcessor/PerfettoTraceProcessor.cs
+++ b/PerfettoProcessor/PerfettoTraceProcessor.cs
@@ -261,6 +261,9 @@ namespace PerfettoProcessor
                                 case PerfettoSchedSliceEvent.Key:
                                     ev = new PerfettoSchedSliceEvent();
                                     break;
+                                case PerfettoAndroidLogEvent.Key:
+                                    ev = new PerfettoAndroidLogEvent();
+                                    break;
                                 default:
                                     throw new Exception("Invalid event type");
                             }

--- a/Utilities/Common.cs
+++ b/Utilities/Common.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 

--- a/Utilities/Common.cs
+++ b/Utilities/Common.cs
@@ -3,10 +3,9 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
-namespace PerfettoCds.Utilities
+namespace Utilities
 {
-    public struct EventProjection<T>
-    : IProjection<int, T>
+    public struct EventProjection<T>: IProjection<int, T>
     {
         private readonly ProcessedEventData<T> events;
 

--- a/Utilities/Common.cs
+++ b/Utilities/Common.cs
@@ -1,26 +1,9 @@
-﻿using Microsoft.Performance.SDK.Processing;
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
 namespace Utilities
 {
-    public struct EventProjection<T>: IProjection<int, T>
-    {
-        private readonly ProcessedEventData<T> events;
-
-        public EventProjection(ProcessedEventData<T> events)
-        {
-            this.events = events;
-        }
-
-        public Type SourceType => typeof(int);
-
-        public Type ResultType => typeof(T);
-
-        public T this[int value] => this.events[(uint)value];
-    }
-
     public class Common
     {
         [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]

--- a/Utilities/EventProjection.cs
+++ b/Utilities/EventProjection.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.Performance.SDK.Processing;
+
+namespace Utilities
+{
+    public struct EventProjection<T> : IProjection<int, T>
+    {
+        private readonly ProcessedEventData<T> events;
+
+        public EventProjection(ProcessedEventData<T> events)
+        {
+            this.events = events;
+        }
+
+        public Type SourceType => typeof(int);
+
+        public Type ResultType => typeof(T);
+
+        public T this[int value] => this.events[(uint)value];
+    }
+}

--- a/Utilities/EventProjection.cs
+++ b/Utilities/EventProjection.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
 using Microsoft.Performance.SDK.Processing;
 
 namespace Utilities

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Performance.SDK" Version="0.109.11-preview-g61bc0d83f6" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Added 3 new tables to the Perfetto plugin.

- Logcat events - Displays all the logcat messages logged during the trace in simple linear timeline. Moved this table to a separate "Android" table group.
- CPU frequency scaling - Displays the frequency chart for each CPU and how it changes. When the CPU goes idle, the CPU frequency is displayed as 0.
- Ftrace events - Displays all the remaining events in the Raw table, which is a lot of the Ftrace events. These are displayed in simple timeline grouped by CPU

Also moved a couple tools that were used by multiple projects to a shared Utility project.