### PR TITLE
Perfetto plugin - Add support for an optional ProviderGuid mapping file

### DIFF
--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoGenericEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoGenericEventCooker.cs
@@ -16,6 +16,9 @@ using System.IO;
 
 namespace PerfettoCds.Pipeline.DataCookers
 {
+    /// <summary>
+    /// XML deserialized EventProvider
+    /// </summary>
     public class EventProvider
     {
         [XmlAttribute("Id")]
@@ -24,6 +27,9 @@ namespace PerfettoCds.Pipeline.DataCookers
         public string Guid { get; set; }
     }
 
+    /// <summary>
+    /// Deserialized root of the ProviderGUID XML file
+    /// </summary>
     [XmlRoot("EventProviders")]
     public class EventProvidersRoot
     {
@@ -91,7 +97,7 @@ namespace PerfettoCds.Pipeline.DataCookers
         }
 
         /// <summary>
-        /// The user can specify a ProviderMapping.xml file that contains a mapping between a Provider name and the provider GUID
+        /// The user can specify a ProviderMapping.xml file that contains a mapping between a Provider name and the Provider GUID
         /// Check for the file in the assembly directory and load the mappings
         /// </summary>
         private void TryLoadProviderGuidXml()

--- a/PerfettoCds/Pipeline/DataOutput/PerfettoGenericEvent.cs
+++ b/PerfettoCds/Pipeline/DataOutput/PerfettoGenericEvent.cs
@@ -32,6 +32,8 @@ namespace PerfettoCds.Pipeline.DataOutput
         // From Thread table
         public string Thread { get; }
 
+        public string Provider { get; }
+
         public PerfettoGenericEvent(string eventName, 
             string type, 
             TimestampDelta duration, 
@@ -42,7 +44,8 @@ namespace PerfettoCds.Pipeline.DataOutput
             List<string> values,
             List<string> argKeys,
             string process,
-            string thread)
+            string thread,
+            string provider)
         {
             this.EventName = eventName;
             this.Type = type;
@@ -55,6 +58,7 @@ namespace PerfettoCds.Pipeline.DataOutput
             this.ArgKeys = argKeys;
             this.Process = process;
             this.Thread = thread;
+            this.Provider = provider;
         }
     }
 }

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -59,7 +59,7 @@ namespace PerfettoCds.Pipeline.Tables
 
         private static readonly ColumnConfiguration ProviderColumn = new ColumnConfiguration(
             new ColumnMetadata(new Guid("{e7d08f97-f52c-4686-bc49-737f7a6a8bbb}"), "Provider", "Provider name of the event"),
-            new UIHints { Width = 210 });
+            new UIHints { Width = 240 });
 
         public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
         {
@@ -68,7 +68,7 @@ namespace PerfettoCds.Pipeline.Tables
             int maxFieldCount = Math.Min(AbsoluteMaxFields, tableData.QueryOutput<int>(
                 new DataOutputPath(PerfettoPluginConstants.GenericEventCookerPath, nameof(PerfettoGenericEventCooker.MaximumEventFieldCount))));
 
-            bool hasProviderMapping = tableData.QueryOutput<bool>(
+            bool hasProviders = tableData.QueryOutput<bool>(
                 new DataOutputPath(PerfettoPluginConstants.GenericEventCookerPath, nameof(PerfettoGenericEventCooker.HasProviders)));
 
             // Get data from the cooker
@@ -139,7 +139,7 @@ namespace PerfettoCds.Pipeline.Tables
             tableGenerator.AddColumn(providerColumn);
 
             // The provider column is optionally populated depending on whether or not the user specified a ProviderGUID mapping file
-            ProviderColumn.DisplayHints.IsVisible = hasProviderMapping;
+            ProviderColumn.DisplayHints.IsVisible = hasProviders;
 
             // Add the field columns, with column names depending on the given event
             for (int index = 0; index < maxFieldCount; index++)

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -4,11 +4,10 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
 using PerfettoCds.Pipeline.DataCookers;
+using Utilities;
 
 namespace PerfettoCds.Pipeline.Tables
 {
@@ -70,7 +69,7 @@ namespace PerfettoCds.Pipeline.Tables
                 new DataOutputPath(PerfettoPluginConstants.GenericEventCookerPath, nameof(PerfettoGenericEventCooker.MaximumEventFieldCount))));
 
             bool hasProviderMapping = tableData.QueryOutput<bool>(
-                new DataOutputPath(PerfettoPluginConstants.GenericEventCookerPath, nameof(PerfettoGenericEventCooker.HasProviderMapping)));
+                new DataOutputPath(PerfettoPluginConstants.GenericEventCookerPath, nameof(PerfettoGenericEventCooker.HasProviders)));
 
             // Get data from the cooker
             var events = tableData.QueryOutput<ProcessedEventData<PerfettoGenericEvent>>(
@@ -91,7 +90,7 @@ namespace PerfettoCds.Pipeline.Tables
             };
 
             var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
-            var genericEventProjection = new GenericEventProjection(events);
+            var genericEventProjection = new EventProjection<PerfettoGenericEvent>(events);
 
             // Add all the data projections
             var processNameColumn = new BaseDataColumn<string>(
@@ -138,6 +137,8 @@ namespace PerfettoCds.Pipeline.Tables
                 ProviderColumn,
                 genericEventProjection.Compose((genericEvent) => genericEvent.Provider));
             tableGenerator.AddColumn(providerColumn);
+
+            // The provider column is optionally populated depending on whether or not the user specified a ProviderGUID mapping file
             ProviderColumn.DisplayHints.IsVisible = hasProviderMapping;
 
             // Add the field columns, with column names depending on the given event
@@ -150,7 +151,7 @@ namespace PerfettoCds.Pipeline.Tables
 
                 // generate a column configuration
                 var fieldColumnConfiguration = new ColumnConfiguration(
-                        new ColumnMetadata(GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
+                        new ColumnMetadata(Common.GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
                         new UIHints
                         {
                             IsVisible = true,
@@ -180,67 +181,6 @@ namespace PerfettoCds.Pipeline.Tables
             tableConfig.AddColumnRole(ColumnRole.Duration, DurationColumn.Metadata.Guid);
 
             tableBuilder.AddTableConfiguration(tableConfig).SetDefaultTableConfiguration(tableConfig);
-        }
-
-        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]
-        private static Guid GenerateGuidFromName(string name)
-        {
-            // The algorithm below is following the guidance of http://www.ietf.org/rfc/rfc4122.txt
-            // Create a blob containing a 16 byte number representing the namespace
-            // followed by the unicode bytes in the name.  
-            var bytes = new byte[name.Length * 2 + 16];
-            uint namespace1 = 0x482C2DB2;
-            uint namespace2 = 0xC39047c8;
-            uint namespace3 = 0x87F81A15;
-            uint namespace4 = 0xBFC130FB;
-            // Write the bytes most-significant byte first.  
-            for (int i = 3; 0 <= i; --i)
-            {
-                bytes[i] = (byte)namespace1;
-                namespace1 >>= 8;
-                bytes[i + 4] = (byte)namespace2;
-                namespace2 >>= 8;
-                bytes[i + 8] = (byte)namespace3;
-                namespace3 >>= 8;
-                bytes[i + 12] = (byte)namespace4;
-                namespace4 >>= 8;
-            }
-            // Write out  the name, most significant byte first
-            for (int i = 0; i < name.Length; i++)
-            {
-                bytes[2 * i + 16 + 1] = (byte)name[i];
-                bytes[2 * i + 16] = (byte)(name[i] >> 8);
-            }
-
-            // Compute the Sha1 hash 
-            var sha1 = SHA1.Create();
-            byte[] hash = sha1.ComputeHash(bytes);
-
-            // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)
-            int a = (((((hash[3] << 8) + hash[2]) << 8) + hash[1]) << 8) + hash[0];
-            short b = (short)((hash[5] << 8) + hash[4]);
-            short c = (short)((hash[7] << 8) + hash[6]);
-
-            c = (short)((c & 0x0FFF) | 0x5000);   // Set high 4 bits of octet 7 to 5, as per RFC 4122
-            Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
-            return guid;
-        }
-
-        public struct GenericEventProjection
-            : IProjection<int, PerfettoGenericEvent>
-        {
-            private readonly ProcessedEventData<PerfettoGenericEvent> genericEvents;
-
-            public GenericEventProjection(ProcessedEventData<PerfettoGenericEvent> genericEvents)
-            {
-                this.genericEvents = genericEvents;
-            }
-
-            public Type SourceType => typeof(int);
-
-            public Type ResultType => typeof(PerfettoGenericEvent);
-
-            public PerfettoGenericEvent this[int value] => this.genericEvents[(uint)value];
         }
     }
 }

--- a/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
+++ b/PerfettoCds/Pipeline/Tables/PerfettoGenericEventTable.cs
@@ -4,10 +4,11 @@ using Microsoft.Performance.SDK.Extensibility;
 using Microsoft.Performance.SDK.Processing;
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Diagnostics.CodeAnalysis;
 using PerfettoCds.Pipeline.DataOutput;
 using Microsoft.Performance.SDK;
 using PerfettoCds.Pipeline.DataCookers;
-using Utilities;
 
 namespace PerfettoCds.Pipeline.Tables
 {
@@ -57,6 +58,10 @@ namespace PerfettoCds.Pipeline.Tables
             new ColumnMetadata(new Guid("{01d2b15f-b0fc-4444-a240-0a96f62c2c50}"), "Type", "Type of the event"),
             new UIHints { Width = 70 });
 
+        private static readonly ColumnConfiguration ProviderColumn = new ColumnConfiguration(
+            new ColumnMetadata(new Guid("{e7d08f97-f52c-4686-bc49-737f7a6a8bbb}"), "Provider", "Provider name of the event"),
+            new UIHints { Width = 210 });
+
         public static void BuildTable(ITableBuilder tableBuilder, IDataExtensionRetrieval tableData)
         {
             // We dynamically adjust the column headers
@@ -64,13 +69,17 @@ namespace PerfettoCds.Pipeline.Tables
             int maxFieldCount = Math.Min(AbsoluteMaxFields, tableData.QueryOutput<int>(
                 new DataOutputPath(PerfettoPluginConstants.GenericEventCookerPath, nameof(PerfettoGenericEventCooker.MaximumEventFieldCount))));
 
+            bool hasProviderMapping = tableData.QueryOutput<bool>(
+                new DataOutputPath(PerfettoPluginConstants.GenericEventCookerPath, nameof(PerfettoGenericEventCooker.HasProviderMapping)));
+
             // Get data from the cooker
             var events = tableData.QueryOutput<ProcessedEventData<PerfettoGenericEvent>>(
                 new DataOutputPath(PerfettoPluginConstants.GenericEventCookerPath, nameof(PerfettoGenericEventCooker.GenericEvents)));
 
             // Start construction of the column order. Pivot on process and thread
-            List<ColumnConfiguration> allColumns = new List<ColumnConfiguration>() 
+            List<ColumnConfiguration> allColumns = new List<ColumnConfiguration>()
             {
+                ProviderColumn,
                 ProcessNameColumn,
                 ThreadNameColumn,
                 TableConfiguration.PivotColumn, // Columns before this get pivotted on
@@ -82,7 +91,7 @@ namespace PerfettoCds.Pipeline.Tables
             };
 
             var tableGenerator = tableBuilder.SetRowCount((int)events.Count);
-            var genericEventProjection = new EventProjection<PerfettoGenericEvent>(events);
+            var genericEventProjection = new GenericEventProjection(events);
 
             // Add all the data projections
             var processNameColumn = new BaseDataColumn<string>(
@@ -125,6 +134,12 @@ namespace PerfettoCds.Pipeline.Tables
                 genericEventProjection.Compose((genericEvent) => genericEvent.Type));
             tableGenerator.AddColumn(typeColumn);
 
+            var providerColumn = new BaseDataColumn<string>(
+                ProviderColumn,
+                genericEventProjection.Compose((genericEvent) => genericEvent.Provider));
+            tableGenerator.AddColumn(providerColumn);
+            ProviderColumn.DisplayHints.IsVisible = hasProviderMapping;
+
             // Add the field columns, with column names depending on the given event
             for (int index = 0; index < maxFieldCount; index++)
             {
@@ -135,7 +150,7 @@ namespace PerfettoCds.Pipeline.Tables
 
                 // generate a column configuration
                 var fieldColumnConfiguration = new ColumnConfiguration(
-                        new ColumnMetadata(Common.GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
+                        new ColumnMetadata(GenerateGuidFromName(fieldName), fieldName, genericEventFieldNameProjection, fieldName),
                         new UIHints
                         {
                             IsVisible = true,
@@ -165,6 +180,67 @@ namespace PerfettoCds.Pipeline.Tables
             tableConfig.AddColumnRole(ColumnRole.Duration, DurationColumn.Metadata.Guid);
 
             tableBuilder.AddTableConfiguration(tableConfig).SetDefaultTableConfiguration(tableConfig);
+        }
+
+        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Not a security related usage - just generating probabilistically unique id to identify a column from its name.")]
+        private static Guid GenerateGuidFromName(string name)
+        {
+            // The algorithm below is following the guidance of http://www.ietf.org/rfc/rfc4122.txt
+            // Create a blob containing a 16 byte number representing the namespace
+            // followed by the unicode bytes in the name.  
+            var bytes = new byte[name.Length * 2 + 16];
+            uint namespace1 = 0x482C2DB2;
+            uint namespace2 = 0xC39047c8;
+            uint namespace3 = 0x87F81A15;
+            uint namespace4 = 0xBFC130FB;
+            // Write the bytes most-significant byte first.  
+            for (int i = 3; 0 <= i; --i)
+            {
+                bytes[i] = (byte)namespace1;
+                namespace1 >>= 8;
+                bytes[i + 4] = (byte)namespace2;
+                namespace2 >>= 8;
+                bytes[i + 8] = (byte)namespace3;
+                namespace3 >>= 8;
+                bytes[i + 12] = (byte)namespace4;
+                namespace4 >>= 8;
+            }
+            // Write out  the name, most significant byte first
+            for (int i = 0; i < name.Length; i++)
+            {
+                bytes[2 * i + 16 + 1] = (byte)name[i];
+                bytes[2 * i + 16] = (byte)(name[i] >> 8);
+            }
+
+            // Compute the Sha1 hash 
+            var sha1 = SHA1.Create();
+            byte[] hash = sha1.ComputeHash(bytes);
+
+            // Create a GUID out of the first 16 bytes of the hash (SHA-1 create a 20 byte hash)
+            int a = (((((hash[3] << 8) + hash[2]) << 8) + hash[1]) << 8) + hash[0];
+            short b = (short)((hash[5] << 8) + hash[4]);
+            short c = (short)((hash[7] << 8) + hash[6]);
+
+            c = (short)((c & 0x0FFF) | 0x5000);   // Set high 4 bits of octet 7 to 5, as per RFC 4122
+            Guid guid = new Guid(a, b, c, hash[8], hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]);
+            return guid;
+        }
+
+        public struct GenericEventProjection
+            : IProjection<int, PerfettoGenericEvent>
+        {
+            private readonly ProcessedEventData<PerfettoGenericEvent> genericEvents;
+
+            public GenericEventProjection(ProcessedEventData<PerfettoGenericEvent> genericEvents)
+            {
+                this.genericEvents = genericEvents;
+            }
+
+            public Type SourceType => typeof(int);
+
+            public Type ResultType => typeof(PerfettoGenericEvent);
+
+            public PerfettoGenericEvent this[int value] => this.genericEvents[(uint)value];
         }
     }
 }

--- a/PerfettoCds/ReadMe.md
+++ b/PerfettoCds/ReadMe.md
@@ -15,3 +15,16 @@ For example, for the slice table, the process goes like this:
 
 ## Trace Processor Shell
 Trace_processor_shell.exe is built from the [Perfetto GitHub repo](https://github.com/google/perfetto). To build this for Windows, follow the instructions from their [documentation](https://perfetto.dev/docs/contributing/build-instructions#building-on-windows) 
+
+## Provider-GUID Mappings
+Perfetto does not surface the name of an event's provider. As a workaround, the Perfetto plugin has support to load a ProviderGuid XML mapping file that maps GUIDs to Provider Names. Using this mapping, the plugin will search each GenericEvent's debug annotations for a specific key that holds a GUID value, and it will convert that GUID to the ProviderName in the mapping. The GenericEvent table will then display an extra column with that Provider name.
+
+To use:
+1. Your GenericEvents should be instrumented to output debug annotations where the argument key is the string "ProviderGuid" and the argument value is the provider GUID string.
+2. Add an XML file with the exact name "ProviderMapping.xml" to the same directory that contains the Perfetto plugin binaries. That directory should contain "PerfettoCds.dll". The XML schema should look like the following. The "DebugAnnotationKey" attribute is optional. That specifies which debug annotation key to look for. It defaults to "ProviderGuid". Add an EventProvider node for each Provider you want mapped.
+
+        <?xml version="1.0" encoding="utf-8"?>
+        <EventProviders DebugAnnotationKey="MyCustomDebugAnnotationKey">
+        <EventProvider Id="My.Trace.Event1" Name="e6cc2436-d77f-495d-96ce-4c46ddc569a0" />
+        <EventProvider Id="My.Trace.Event2" Name="a30f819e-db13-4523-b578-1f1a0b4d6533" />
+        </EventProviders>

--- a/PerfettoCds/ReadMe.md
+++ b/PerfettoCds/ReadMe.md
@@ -21,7 +21,7 @@ Perfetto does not surface the name of an event's provider. As a workaround, the 
 
 To use:
 1. Your GenericEvents should be instrumented to output debug annotations where the argument key is the string "ProviderGuid" and the argument value is the provider GUID string.
-2. Add an XML file with the exact name "ProviderMapping.xml" to the same directory that contains the Perfetto plugin binaries. That directory should contain "PerfettoCds.dll". The XML schema should look like the following. The "DebugAnnotationKey" attribute is optional. That specifies which debug annotation key to look for. It defaults to "ProviderGuid". Add an EventProvider node for each Provider you want mapped.
+2. Add an XML file with the exact name "ProviderMapping.xml" to the same directory that contains the Perfetto plugin binaries. That directory is the one containing "PerfettoCds.dll". The XML schema should look like the following. The "DebugAnnotationKey" attribute is optional. That specifies which debug annotation key to look for. It defaults to "ProviderGuid". Add an EventProvider node for each Provider you want mapped.
 
         <?xml version="1.0" encoding="utf-8"?>
         <EventProviders DebugAnnotationKey="MyCustomDebugAnnotationKey">

--- a/PerfettoProcessor/PerfettoTraceProcessor.cs
+++ b/PerfettoProcessor/PerfettoTraceProcessor.cs
@@ -24,8 +24,8 @@ namespace PerfettoProcessor
         // Highest ports can go
         private const int PortMax = 65535;
 
-        // HTTP request denied takes about 3 seconds so time out after about 2 minutes
-        private const int MaxRetryLimit = 40;
+        // HTTP request denied takes about 3 seconds so time out after about 5 minutes
+        private const int MaxRetryLimit = 100;
 
         /// <summary>
         /// Sends an RPC request to trace_processor_shell. This utilizies the bidirectional pipe that exists with the /rpc endpoint.


### PR DESCRIPTION
In Windows traces, the Provider name of each event is output along with all the event fields. Perfetto does not output the original provider name or GUID for an event. This change adds a workaround for that. It adds support for the loading of an optional XML file that has a mapping between a Provider Name and a Provider GUID. If the user then instruments their code to output the provider GUID as a debug annotation value with a specific key, the full Provider Name will be retrieved for that GUID and added as a column to the GenericEvent viewer.

The ProviderMapping.xml file needs to be placed in the plugin directory with all the binaries.