### PR TITLE
Perfetto plugin - Added build tasks to download trace_processor_shell

### DIFF
--- a/PerfettoCds/PerfettoCds.csproj
+++ b/PerfettoCds/PerfettoCds.csproj
@@ -16,7 +16,19 @@
     <ProjectReference Include="..\Utilities\Utilities.csproj" />
   </ItemGroup>
 
+  <Target Name="DownloadTraceProcessorShell">
+    <!-- Download the trace_processor.exe from Perfetto's GitHub release and copy it to the output directory-->
+    <Copy SourceFiles="$(PkgGoogle_Protobuf)\lib\netstandard2.0\Google.Protobuf.dll" DestinationFolder="$(TargetDir)" />
+    <DownloadFile SourceUrl="https://github.com/google/perfetto/releases/download/v18.0/windows-amd64.zip" DestinationFolder="$(TargetDir)" />
+    <Unzip SourceFiles="$(TargetDir)\windows-amd64.zip" DestinationFolder="$(TargetDir)" />
+    <Copy SourceFiles="$(TargetDir)\windows-amd64\trace_processor_shell.exe" DestinationFolder="$(TargetDir)" />
+    <RemoveDir Directories="$(TargetDir)\windows-amd64"/>
+    <Delete Files="$(TargetDir)\windows-amd64.zip"/>
+  </Target>
+
   <Target Name="CopyRulesToTarget" AfterTargets="Build">
     <Copy SourceFiles="$(PkgGoogle_Protobuf)\lib\netstandard2.0\Google.Protobuf.dll" DestinationFolder="$(TargetDir)" />
+    <!-- Download trace_processor_shell to the output directory if it doesn't exist -->
+    <CallTarget Condition="!Exists('$(TargetDir)\trace_processor_shell.exe')" Targets="DownloadTraceProcessorShell"  />
   </Target>
 </Project>

--- a/PerfettoCds/Pipeline/PerfettoDataSource.cs
+++ b/PerfettoCds/Pipeline/PerfettoDataSource.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace PerfettoCds
 {
-    [CustomDataSource("9fc8515e-9206-4690-b14a-3e7b54745c5f", "Perfetto DataSource", "Processes Perfetto trace files")]
+    [CustomDataSource("9fc8515e-9206-4690-b14a-3e7b54745c5f", "PerfettoTraceDataSource", "Processes Perfetto trace files")]
     [FileDataSource(".perfetto-trace", "Perfetto trace files")]
     public sealed class PerfettoDataSource : CustomDataSourceBase
     {
@@ -70,7 +70,7 @@ namespace PerfettoCds
         }
     }
 
-    [CustomDataSource("99e4223a-6211-4ce7-a0da-917a893797f2", "Perfetto DataSource", "Processes Perfetto trace files")]
+    [CustomDataSource("99e4223a-6211-4ce7-a0da-917a893797f2", "PftraceDataSource", "Processes .pftrace Perfetto trace files")]
     [FileDataSource(".pftrace", "Perfetto trace files")]
     public sealed class PfDataSource : CustomDataSourceBase
     {


### PR DESCRIPTION
We wanted to set up a NuGet pipeline in the Perfetto repo, but the Perfetto team does not want to maintain another packaging pipeline, even if we set it up. We could publish the package ourselves, but I don't think we want to maintain that and it seems weird for Microsoft to publish a NuGet package for Google tools.

Perfetto does publish to CIPD, GCS, and GitHub releases, so I made some VS build tasks to download a specific release from GitHub and copy the .exe we want to the the build directory.

Also added unique names for the 2 DataSources, since that messed up some scenarios in WPA (like using wpaexporter).