### PR TITLE
Perfetto plugin - Fix for missing absolute trace start time

### DIFF
--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoFtraceEventCooker.cs
@@ -80,6 +80,7 @@ namespace PerfettoCds.Pipeline.DataCookers
                     argKeys.Add(arg.ArgKey);
                     switch (arg.ValueType)
                     {
+                        case "json":
                         case "string":
                             values.Add(arg.StringValue);
                             break;

--- a/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoGenericEventCooker.cs
+++ b/PerfettoCds/Pipeline/CompositeDataCookers/PerfettoGenericEventCooker.cs
@@ -177,6 +177,7 @@ namespace PerfettoCds.Pipeline.DataCookers
                     argKeys.Add(arg.ArgKey);
                     switch (arg.ValueType)
                     {
+                        case "json":
                         case "string":
                             values.Add(arg.StringValue);
 

--- a/PerfettoCds/Pipeline/PerfettoSourceParser.cs
+++ b/PerfettoCds/Pipeline/PerfettoSourceParser.cs
@@ -176,8 +176,13 @@ namespace PerfettoCds
                     // If we have all the timing data we need, create the DataSourceInfo
                     if (++cnt == minQueriesForTimings)
                     {
-                        if (firstEventTime != Timestamp.MaxValue && lastEventTime != Timestamp.MinValue && traceStartDateTime.HasValue)
+                        if (firstEventTime != Timestamp.MaxValue && lastEventTime != Timestamp.MinValue)
                         {
+                            if (!traceStartDateTime.HasValue)
+                            {
+                                logger.Warn($"Absolute trace start time can't be determined. Setting trace start time to now");
+                                traceStartDateTime = DateTime.Now;
+                            }
                             // Get the delta between the first event time and the first snapshot time
                             var startDelta = firstEventTime - firstSnapTime;
 


### PR DESCRIPTION
Edge traces are missing the required UTC clocks for gathering the absolute trace start time and that caused the DataSourceInfo to not be initialized, which causes no events to be displayed. Added support to default to DateTime.Now for missing absolute trace start.

Also added a couple new value types for args.